### PR TITLE
Implement reconciler `prepareUpdate`

### DIFF
--- a/src/utils/props.js
+++ b/src/utils/props.js
@@ -4,13 +4,14 @@ import * as PIXI from 'pixi.js'
 import { eventHandlers, setValue } from './pixi'
 import { isFunction, not, hasKey } from '../helpers'
 
+export const CHILDREN = 'children'
 /**
  * Reserved props
  *
  * @type {Object}
  */
 export const PROPS_RESERVED = {
-  children: true,
+  [CHILDREN]: true,
   parent: true,
   worldAlpha: true,
   worldTransform: true,


### PR DESCRIPTION
Only commit updates in the render tree that are actually changed.

See also [ReactDOM Reconciler](https://github.com/facebook/react/blob/97e2911/packages/react-dom/src/client/ReactDOMFiberComponent.js#L546)

`prepareUpdate` now returns the props that needs to update. If there's nothing to update, it just returns null.