### PR TITLE
Apply props for built in PIXI components, see #9

### DIFF
--- a/src/components/Graphics.js
+++ b/src/components/Graphics.js
@@ -1,7 +1,7 @@
 import * as PIXI from 'pixi.js'
 import { applyDefaultProps } from '../utils/props'
 
-const Graphics = () => {
+const Graphics = (root, props) => {
   const g = new PIXI.Graphics()
 
   g.applyProps = (instance, oldProps, newProps) => {

--- a/src/components/Mesh.js
+++ b/src/components/Mesh.js
@@ -1,9 +1,19 @@
 import * as PIXI from 'pixi.js'
-import { getTextureFromProps } from '../utils/props'
+import { applyDefaultProps, getTextureFromProps } from '../utils/props'
 
 const Mesh = (root, props) => {
-  const texture = getTextureFromProps('Mesh', props)
-  return new PIXI.mesh.Mesh(texture)
+  const mesh = new PIXI.mesh.Mesh(getTextureFromProps('Mesh', props))
+
+  mesh.applyProps = (instance, oldProps, newProps) => {
+    const { image, texture, ...props } = newProps
+    applyDefaultProps(instance, oldProps, props)
+
+    if (image || texture) {
+      instance.texture = getTextureFromProps('Mesh', newProps)
+    }
+  }
+
+  return mesh
 }
 
 export default Mesh

--- a/src/components/NineSlicePlane.js
+++ b/src/components/NineSlicePlane.js
@@ -1,11 +1,22 @@
 import * as PIXI from 'pixi.js'
-import { getTextureFromProps } from '../utils/props'
+import { getTextureFromProps, applyDefaultProps } from '../utils/props'
 
 const NineSlicePlane = (root, props) => {
   const { leftWidth = 10, topHeight = 10, rightWidth = 10, bottomHeight = 10 } = props
   const texture = getTextureFromProps('NineSlicePlane', props)
 
-  return new PIXI.mesh.NineSlicePlane(texture, leftWidth, topHeight, rightWidth, bottomHeight)
+  const nineSlicePlane = new PIXI.mesh.NineSlicePlane(texture, leftWidth, topHeight, rightWidth, bottomHeight)
+
+  nineSlicePlane.applyProps = (instance, oldProps, newProps) => {
+    const { image, texture, ...props } = newProps
+    applyDefaultProps(instance, oldProps, props)
+
+    if (image || texture) {
+      instance.texture = getTextureFromProps('NineSlicePlane', newProps)
+    }
+  }
+
+  return nineSlicePlane
 }
 
 export default NineSlicePlane

--- a/src/components/Rope.js
+++ b/src/components/Rope.js
@@ -1,13 +1,25 @@
 import * as PIXI from 'pixi.js'
 import invariant from 'fbjs/lib/invariant'
-import { getTextureFromProps } from '../utils/props'
+import { getTextureFromProps, applyDefaultProps } from '../utils/props'
 
 const Rope = (root, props) => {
   const texture = getTextureFromProps('Rope', props)
   const { points } = props
 
-  invariant(Array.isArray(points), 'Rope points needs to be %s', 'Array<PIXI.Point>')
-  return new PIXI.mesh.Rope(texture, points)
+  const rope = new PIXI.mesh.Rope(texture, points)
+
+  rope.applyProps = (instance, oldProps, newProps) => {
+    const { image, texture, ...props } = newProps
+
+    invariant(Array.isArray(newProps.points), 'Rope points needs to be %s', 'Array<PIXI.Point>')
+    applyDefaultProps(instance, oldProps, props)
+
+    if (image || texture) {
+      instance.texture = getTextureFromProps('Rope', newProps)
+    }
+  }
+
+  return rope
 }
 
 export default Rope

--- a/src/components/Sprite.js
+++ b/src/components/Sprite.js
@@ -1,9 +1,19 @@
 import * as PIXI from 'pixi.js'
-import { getTextureFromProps } from '../utils/props'
+import { getTextureFromProps, applyDefaultProps } from '../utils/props'
 
 const Sprite = (root, props) => {
-  const texture = getTextureFromProps('Sprite', props)
-  return new PIXI.Sprite(texture)
+  const sprite = new PIXI.Sprite(getTextureFromProps('Sprite', props))
+
+  sprite.applyProps = (instance, oldProps, newProps) => {
+    const { image, texture, ...props } = newProps
+    applyDefaultProps(instance, oldProps, props)
+
+    if (image || texture) {
+      instance.texture = getTextureFromProps('Sprite', newProps)
+    }
+  }
+
+  return sprite
 }
 
 export default Sprite

--- a/src/components/TilingSprite.js
+++ b/src/components/TilingSprite.js
@@ -9,7 +9,7 @@ const TilingSprite = (root, props) => {
   const ts = new PIXI.extras.TilingSprite(texture, width, height)
 
   ts.applyProps = (instance, oldProps, newProps) => {
-    const { tileScale, tilePosition, ...props } = newProps
+    const { tileScale, tilePosition, image, texture, ...props } = newProps
     applyDefaultProps(instance, oldProps, props)
 
     if (tilePosition) {
@@ -18,6 +18,10 @@ const TilingSprite = (root, props) => {
 
     if (tileScale) {
       instance.tileScale.set(...parsePoint(tileScale))
+    }
+
+    if (image || texture) {
+      instance.texture = getTextureFromProps('Sprite', newProps)
     }
   }
 

--- a/test/element.spec.js
+++ b/test/element.spec.js
@@ -68,6 +68,106 @@ describe('createElement', () => {
   })
 })
 
+describe('element.applyProps', () => {
+  let spy
+
+  beforeAll(() => {
+    spy = jest.spyOn(PIXI.Texture, 'fromImage').mockReturnValue(emptyTexture)
+  })
+
+  afterAll(() => {
+    spy.mockRestore()
+  })
+
+  test('Sprite.applyProps exists', () => {
+    const element = createElement(TYPES.Sprite, { image: './image.png' })
+    expect(element).toHaveProperty('applyProps')
+    expect(spy).toHaveBeenCalledWith('./image.png')
+  })
+
+  test('Sprite.applyProps image', () => {
+    const element = createElement(TYPES.Sprite, { image: './image.png' })
+    expect(spy).lastCalledWith('./image.png')
+
+    element.applyProps(element, { image: './image.png' }, { image: './new-image.png' })
+    expect(spy).lastCalledWith('./new-image.png')
+  })
+
+  test('TilingSprite.applyProps exists', () => {
+    const element = createElement(TYPES.TilingSprite, { image: './image.png' })
+    expect(element).toHaveProperty('applyProps')
+    expect(spy).toHaveBeenCalledWith('./image.png')
+  })
+
+  test('TilingSprite.applyProps image', () => {
+    const element = createElement(TYPES.TilingSprite, { image: './image.png' })
+    expect(spy).lastCalledWith('./image.png')
+
+    element.applyProps(element, { image: './image.png' }, { image: './new-image.png' })
+    expect(spy).lastCalledWith('./new-image.png')
+  })
+
+  test('Rope.applyProps exists', () => {
+    const element = createElement(TYPES.Rope, { image: './image.png', points: [] })
+    expect(element).toHaveProperty('applyProps')
+    expect(spy).toHaveBeenCalledWith('./image.png')
+  })
+
+  test('Rope.applyProps image', () => {
+    const element = createElement(TYPES.Rope, { image: './image.png', points: [] })
+    expect(spy).lastCalledWith('./image.png')
+
+    element.applyProps(element, { image: './image.png' }, { image: './new-image.png', points: [] })
+    expect(spy).lastCalledWith('./new-image.png')
+  })
+
+  test('NineSlicePlane.applyProps exists', () => {
+    const element = createElement(TYPES.NineSlicePlane, { image: './image.png' })
+    expect(element).toHaveProperty('applyProps')
+    expect(spy).toHaveBeenCalledWith('./image.png')
+  })
+
+  test('NineSlicePlane.applyProps image', () => {
+    const element = createElement(TYPES.NineSlicePlane, { image: './image.png' })
+    expect(spy).lastCalledWith('./image.png')
+
+    element.applyProps(element, { image: './image.png' }, { image: './new-image.png' })
+    expect(spy).lastCalledWith('./new-image.png')
+  })
+
+  test('Mesh.applyProps exists', () => {
+    const element = createElement(TYPES.Mesh, { image: './image.png' })
+    expect(element).toHaveProperty('applyProps')
+    expect(spy).toHaveBeenCalledWith('./image.png')
+  })
+
+  test('Mesh.applyProps image', () => {
+    const element = createElement(TYPES.Mesh, { image: './image.png' })
+    expect(spy).lastCalledWith('./image.png')
+
+    element.applyProps(element, { image: './image.png' }, { image: './new-image.png' })
+    expect(spy).lastCalledWith('./new-image.png')
+  })
+
+  test('Graphics.applyProps exists', () => {
+    const spy = jest.fn()
+
+    const element = createElement(TYPES.Graphics, { draw: spy })
+    expect(element).toHaveProperty('applyProps')
+    expect(spy).toBeCalledWith(element)
+  })
+
+  test('Graphics.applyProps draw', () => {
+    const spy = jest.fn()
+
+    const element = createElement(TYPES.Graphics, { draw: spy })
+    expect(spy).toHaveBeenCalledTimes(1)
+
+    element.applyProps(element, { draw: spy }, { draw: spy })
+    expect(spy).toHaveBeenCalledTimes(2)
+  })
+})
+
 describe('PixiComponent', () => {
   afterEach(() => {
     Object.keys(TYPES_INJECTED).forEach(k => {


### PR DESCRIPTION
Sugar syntactic props for built-in PIXI components gets update now as well.
Fix #9 

For example:

```js
class Image extends React.Component {
  state = { image: 'image.png' }

  render() {
    return (
      <Sprite image={this.state.image} 
              onClick={() => this.setState({ image: 'new-image.png' })} />
    )
  } 
}
```

and

```js
class Image extends React.Component {
  state = { count: 1 }

  render() {
    return (
      <Graphics draw={this.draw} 
                onClick={() => this.setState({ count }) => ({ count: count + 1 })} />
    )
  } 

  draw = (g) => {
    g.beginFill(0xcc0000)

    let count = this.state.count
    while(count--) {
      g.drawRect(count * 100, 0, 50, 50)
    }
    g.endFill()
  }
}
```