### PR TITLE
windows compilation + better types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,20 +1,19 @@
-import * as React from 'react';
-import * as PIXI from 'pixi.js';
+import * as PIXI from 'pixi.js'
+import * as React from 'react'
 
 declare namespace _ReactPixi {
-  type Diff<T extends string, U extends string> = ({ [P in T]: P } &
-    { [P in U]: never } & { [x: string]: never })[T];
+  type Diff<T extends string, U extends string> = ({ [P in T]: P } & { [P in U]: never } & { [x: string]: never })[T]
 
-  type Omit<T, K extends keyof T> = Pick<T, Diff<keyof T, K>>;
+  type Omit<T, K extends keyof T> = Pick<T, Diff<keyof T, K>>
 
   interface ObjectWithChildren {
-    children?: any;
+    children?: any
   }
 
-  type Childless<T extends ObjectWithChildren> = Omit<T, 'children'>;
+  type Childless<T extends ObjectWithChildren> = Omit<T, 'children'>
 
   interface ChildrenProperties {
-    children?: React.ReactNode;
+    children?: React.ReactNode
   }
 }
 
@@ -30,47 +29,28 @@ declare namespace ReactPixi {
    * -------------------------------------------
    */
 
-  interface StageProps {
-    children: React.ReactNode;
+  interface StageProps extends React.CanvasHTMLAttributes<HTMLCanvasElement> {
+    children?: React.ReactNode
 
-    width?: number;
-    height?: number;
+    width?: number
+    height?: number
 
-    onMount?(callback: () => PIXI.Application): void;
+    onMount?(callback: () => PIXI.Application): void
 
-    raf?: boolean;
-    renderOnComponentChange?: boolean;
+    raf?: boolean
+    renderOnComponentChange?: boolean
 
-    options?: {
-      antialias?: boolean;
-      autoStart?: boolean;
-      width?: number;
-      height?: number;
-      transparent?: boolean;
-      preserveDrawingBuffer?: boolean;
-      resolution?: number;
-      forceCanvas?: boolean;
-      backgroundColor?: number;
-      clearBeforeRender?: boolean;
-      roundPixels?: boolean;
-      forceFXAA?: boolean;
-      legacy?: boolean;
-      powerPreference?: string;
-      sharedTicker?: boolean;
-      sharedLoader?: boolean;
-      view?: HTMLCanvasElement;
-    };
+    options?: PIXI.ApplicationOptions
   }
-
-  class Stage extends React.Component<StageProps> {}
+  const Stage: React.SFC<StageProps>
 
   function render(
     pixiElement: PIXI.DisplayObject | PIXI.DisplayObject[],
     pixiContainer: PIXI.Container,
     callback?: Function
-  ): void;
+  ): void
 
-  function withPixiApp(baseComponent: React.Component): React.Component;
+  function withPixiApp(baseComponent: React.Component): React.Component
 
   /**
    * -------------------------------------------
@@ -79,10 +59,9 @@ declare namespace ReactPixi {
    */
 
   interface ProviderProps {
-    children(app: PIXI.Application): React.ReactNode;
+    children(app: PIXI.Application): React.ReactNode
   }
-
-  class Provider extends React.Component<ProviderProps> {}
+  const Provider: React.SFC<ProviderProps>
 
   /**
    * -------------------------------------------
@@ -90,12 +69,9 @@ declare namespace ReactPixi {
    * -------------------------------------------
    */
 
-  type ChildlessComponent<T extends _ReactPixi.ObjectWithChildren> = Partial<
-    _ReactPixi.Childless<T>
-  >;
+  type ChildlessComponent<T extends _ReactPixi.ObjectWithChildren> = Partial<_ReactPixi.Childless<T>>
 
-  type Component<T extends _ReactPixi.ObjectWithChildren> = ChildlessComponent<T> &
-    _ReactPixi.ChildrenProperties;
+  type Component<T extends _ReactPixi.ObjectWithChildren> = ChildlessComponent<T> & _ReactPixi.ChildrenProperties
 
   /**
    * -------------------------------------------
@@ -103,14 +79,18 @@ declare namespace ReactPixi {
    * -------------------------------------------
    */
 
-  interface LifeCycleMethods {
-    create(props: object): PIXI.DisplayObject;
-    didMount(instance: PIXI.DisplayObject, parent: PIXI.Container): void;
-    willUnmount(instance: PIXI.DisplayObject, parent: PIXI.Container): void;
-    applyProps(instance: PIXI.DisplayObject, oldProps: object, newProps: object): void;
+  interface LifeCycleMethods<P, PixiInstance extends PIXI.DisplayObject> {
+    create(props: P): PixiInstance
+    didMount?(instance: PixiInstance, parent: PIXI.Container): void
+    willUnmount?(instance: PixiInstance, parent: PIXI.Container): void
+    applyProps?(instance: PixiInstance, oldProps: Readonly<P>, newProps: Readonly<P>): void
   }
 
-  function PixiComponent<T extends string>(type: T, lifecycle: LifeCycleMethods): T;
+  // e.g. const Circle = PixiComponent<{radius: number}, PIXI.Graphics>(...)
+  function PixiComponent<P, PixiInstance extends PIXI.DisplayObject>(
+    type: string,
+    lifecycle: LifeCycleMethods<P, PixiInstance>
+  ): React.SFC<P>
 
   /**
    * -------------------------------------------
@@ -119,60 +99,51 @@ declare namespace ReactPixi {
    */
 
   interface BitmapTextProperties extends ChildlessComponent<PIXI.extras.BitmapText> {
-    text: string;
+    text: string
   }
-
-  class BitmapText extends React.Component<BitmapTextProperties> {}
+  const BitmapText: React.SFC<BitmapTextProperties>
 
   interface ContainerProperties extends Component<PIXI.Container> {}
-
-  class Container extends React.Component<ContainerProperties> {}
+  const Container: React.SFC<ContainerProperties>
 
   interface GraphicsProperties extends ChildlessComponent<PIXI.Graphics> {
-    draw(graphics: PIXI.Graphics): void;
+    draw(graphics: PIXI.Graphics): void
   }
-
-  class Graphics extends React.Component<GraphicsProperties> {}
+  const Graphics: React.SFC<GraphicsProperties>
 
   interface ParticleContainerProperties extends Component<PIXI.particles.ParticleContainer> {}
-
-  class ParticleContainer extends React.Component<ParticleContainerProperties> {}
+  const ParticleContainer: React.SFC<ParticleContainerProperties>
 
   interface SpriteProperties extends ChildlessComponent<PIXI.Sprite> {
-    texture?: PIXI.Texture;
-    image?: string;
+    texture?: PIXI.Texture
+    image?: string
   }
-
-  class Sprite extends React.Component<SpriteProperties> {}
+  const Sprite: React.SFC<SpriteProperties>
 
   interface TextProperties extends ChildlessComponent<PIXI.Text> {}
-
-  class Text extends React.Component<TextProperties> {}
+  const Text: React.SFC<TextProperties>
 
   interface TilingSpriteProperties extends ChildlessComponent<PIXI.extras.TilingSprite> {
-    texture?: PIXI.Texture;
-    image?: string;
+    texture?: PIXI.Texture
+    image?: string
   }
-
-  class TilingSprite extends React.Component<TilingSpriteProperties> {}
+  const TilingSprite: React.SFC<TilingSpriteProperties>
 
   interface MeshProperties extends ChildlessComponent<PIXI.mesh.Mesh> {}
-
-  class Mesh extends React.Component<MeshProperties> {}
+  const Mesh: React.SFC<MeshProperties>
 
   interface RopeProperties extends ChildlessComponent<PIXI.mesh.Rope> {
-    texture?: PIXI.Texture;
-    image?: string;
+    texture?: PIXI.Texture
+    image?: string
   }
-
-  class Rope extends React.Component<RopeProperties> {}
+  const Rope: React.SFC<RopeProperties>
 
   interface NineSlicePlaneProperties extends ChildlessComponent<PIXI.mesh.NineSlicePlane> {
-    texture?: PIXI.Texture;
-    image?: string;
+    texture?: PIXI.Texture
+    image?: string
   }
-
-  class NineSlicePlane extends React.Component<NineSlicePlaneProperties> {}
+  const NineSlicePlane: React.SFC<NineSlicePlaneProperties>
 }
 
-export = ReactPixi;
+export = ReactPixi
+export as namespace ReactPixi

--- a/index.d.ts
+++ b/index.d.ts
@@ -40,7 +40,7 @@ declare namespace ReactPixi {
 
     options?: PIXI.ApplicationOptions
   }
-  const Stage: React.SFC<StageProps>
+  const Stage: React.ComponentType<StageProps>
 
   function render(
     pixiElement: PIXI.DisplayObject | PIXI.DisplayObject[],
@@ -61,7 +61,7 @@ declare namespace ReactPixi {
   interface ProviderProps {
     children(app: PIXI.Application): React.ReactNode
   }
-  const Provider: React.SFC<ProviderProps>
+  const Provider: React.ComponentType<ProviderProps>
 
   /**
    * -------------------------------------------
@@ -90,7 +90,7 @@ declare namespace ReactPixi {
   function PixiComponent<P, PixiInstance extends PIXI.DisplayObject>(
     type: string,
     lifecycle: LifeCycleMethods<P, PixiInstance>
-  ): React.SFC<P>
+  ): React.ComponentType<P>
 
   /**
    * -------------------------------------------
@@ -101,48 +101,48 @@ declare namespace ReactPixi {
   interface BitmapTextProperties extends ChildlessComponent<PIXI.extras.BitmapText> {
     text: string
   }
-  const BitmapText: React.SFC<BitmapTextProperties>
+  const BitmapText: React.ComponentType<BitmapTextProperties>
 
   interface ContainerProperties extends Component<PIXI.Container> {}
-  const Container: React.SFC<ContainerProperties>
+  const Container: React.ComponentType<ContainerProperties>
 
   interface GraphicsProperties extends ChildlessComponent<PIXI.Graphics> {
     draw(graphics: PIXI.Graphics): void
   }
-  const Graphics: React.SFC<GraphicsProperties>
+  const Graphics: React.ComponentType<GraphicsProperties>
 
   interface ParticleContainerProperties extends Component<PIXI.particles.ParticleContainer> {}
-  const ParticleContainer: React.SFC<ParticleContainerProperties>
+  const ParticleContainer: React.ComponentType<ParticleContainerProperties>
 
   interface SpriteProperties extends ChildlessComponent<PIXI.Sprite> {
     texture?: PIXI.Texture
     image?: string
   }
-  const Sprite: React.SFC<SpriteProperties>
+  const Sprite: React.ComponentType<SpriteProperties>
 
   interface TextProperties extends ChildlessComponent<PIXI.Text> {}
-  const Text: React.SFC<TextProperties>
+  const Text: React.ComponentType<TextProperties>
 
   interface TilingSpriteProperties extends ChildlessComponent<PIXI.extras.TilingSprite> {
     texture?: PIXI.Texture
     image?: string
   }
-  const TilingSprite: React.SFC<TilingSpriteProperties>
+  const TilingSprite: React.ComponentType<TilingSpriteProperties>
 
   interface MeshProperties extends ChildlessComponent<PIXI.mesh.Mesh> {}
-  const Mesh: React.SFC<MeshProperties>
+  const Mesh: React.ComponentType<MeshProperties>
 
   interface RopeProperties extends ChildlessComponent<PIXI.mesh.Rope> {
     texture?: PIXI.Texture
     image?: string
   }
-  const Rope: React.SFC<RopeProperties>
+  const Rope: React.ComponentType<RopeProperties>
 
   interface NineSlicePlaneProperties extends ChildlessComponent<PIXI.mesh.NineSlicePlane> {
     texture?: PIXI.Texture
     image?: string
   }
-  const NineSlicePlane: React.SFC<NineSlicePlaneProperties>
+  const NineSlicePlane: React.ComponentType<NineSlicePlaneProperties>
 }
 
 export = ReactPixi

--- a/index.d.ts
+++ b/index.d.ts
@@ -50,7 +50,9 @@ declare namespace ReactPixi {
     callback?: Function
   ): void
 
-  function withPixiApp(baseComponent: React.Component): React.Component
+  function withPixiApp<P extends { app: PIXI.Application }>(
+    baseComponent: React.ComponentType<P>
+  ): React.ComponentType<_ReactPixi.Omit<P, 'app'>>
 
   /**
    * -------------------------------------------

--- a/index.d.ts
+++ b/index.d.ts
@@ -2,9 +2,7 @@ import * as PIXI from 'pixi.js'
 import * as React from 'react'
 
 declare namespace _ReactPixi {
-  type Diff<T extends string, U extends string> = ({ [P in T]: P } & { [P in U]: never } & { [x: string]: never })[T]
-
-  type Omit<T, K extends keyof T> = Pick<T, Diff<keyof T, K>>
+  type Omit<T, K> = Pick<T, Exclude<keyof T, K>>
 
   interface ObjectWithChildren {
     children?: any

--- a/package.json
+++ b/package.json
@@ -9,21 +9,15 @@
   "repository": "git+https://github.com/inlet/react-pixi.git",
   "scripts": {
     "eslint": "eslint .",
-    "build:watch": "NODE_ENV=development rollup -c --watch",
-    "build:dev": "NODE_ENV=development rollup -c",
+    "build:watch": "cross-env NODE_ENV=development rollup -c --watch",
+    "build:dev": "cross-env NODE_ENV=development rollup -c",
     "build:prod": "rollup -c",
     "build": "rimraf ./dist && npm run build:dev && npm run build:prod",
     "test": "jest --silent",
     "test:watch": "jest --silent --watch",
     "prepublish": "npm run test && npm run eslint && npm run build"
   },
-  "files": [
-    "dist/",
-    "LICENSE",
-    "index.d.ts",
-    "index.js",
-    "module.js"
-  ],
+  "files": ["dist/", "LICENSE", "index.d.ts", "index.js", "module.js"],
   "typings": "./index.d.ts",
   "devDependencies": {
     "@babel/cli": "^7.0.0-beta.42",
@@ -39,6 +33,7 @@
     "babel-eslint": "^8.2.2",
     "babel-jest": "^22.4.3",
     "canvas-prebuilt": "^1.6.5-prerelease.1",
+    "cross-env": "^5.1.6",
     "eslint": "^4.18.2",
     "eslint-config-prettier": "^2.9.0",
     "eslint-plugin-prettier": "^2.6.0",
@@ -76,9 +71,7 @@
   },
   "jest": {
     "collectCoverage": false,
-    "setupFiles": [
-      "./test/bootstrap.js"
-    ],
+    "setupFiles": ["./test/bootstrap.js"],
     "transform": {
       "^.+\\.jsx?$": "babel-jest"
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1679,6 +1679,13 @@ core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
 
+cross-env@^5.1.6:
+  version "5.1.6"
+  resolved "https://registry.yarnpkg.com/cross-env/-/cross-env-5.1.6.tgz#0dc05caf945b24e4b9e3b12871fe0e858d08b38d"
+  dependencies:
+    cross-spawn "^5.1.0"
+    is-windows "^1.0.0"
+
 cross-spawn@^5.0.1, cross-spawn@^5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-5.1.0.tgz#e8bd0efee58fcff6f8f94510a0a554bbfa235449"
@@ -2854,7 +2861,7 @@ is-utf8@^0.2.0:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/is-utf8/-/is-utf8-0.2.1.tgz#4b0da1442104d1b336340e80797e865cf39f7d72"
 
-is-windows@^1.0.2:
+is-windows@^1.0.0, is-windows@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/is-windows/-/is-windows-1.0.2.tgz#d1850eb9791ecd18e6182ce12a30f396634bb19d"
 


### PR DESCRIPTION
First of all this pull request adds windows compilation support thanks to cross-env (dev dependency)

Also I fixed more typing issues, the only new thing is that in order to get proper typings PixiComponent has to be used like this in TS:
```
interface CircleProps { radius: number; }
const Circle = PixiComponent<CircleProps, PIXI.Graphics>(...)
```

The good thing is that now lifecycle methods are properly typed with the given Props interface, get the proper PIXI display object type and also when such component is used inside JSX the properties are properly validated.

PS: withPixiApp type as a decorator is still kind of broken, but it works properly as a function (this is, the wrapped class can accept a mandatory app prop and it won't be asked when using the wrapping element)

Also, changes in style are because of prettier.

Btw, options are now typed as  PIXI.ApplicationOptions, should the shape be updated or was there any reason for the custom type (which if needed could be changed to a Pick<PIXI.ApplicationOptions, "a"|"b"|...)?