### PR TITLE
fix typings in render()

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -43,7 +43,10 @@ declare namespace ReactPixi {
   const Stage: React.ComponentType<StageProps>
 
   function render(
-    reactPixiElement: React.ReactElement<any> | React.ReactElement<any>[],
+    reactPixiElement:
+      React.ReactElement<any> |
+      React.ReactElement<any>[] |
+      React.Factory<any>,
     pixiContainer: PIXI.Container,
     callback?: Function
   ): void


### PR DESCRIPTION
With this pitch, you can use a factory function as 1st param for render function.

```typescript
const SuperText = t => <ReactPixi.Text text={'Super ' + t} />

render(
  SuperText, // will work
  app.stage
)
```