### PR TITLE
build:dev *.es5* output is es5 compatible according to es-check tool.

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -25,7 +25,8 @@ export default {
     },
     {
       file: outputFile('es5'),
-      format: 'es'
+      format: 'iife',
+      name: 'ReactPixi'
     },
   ],
   plugins: [


### PR DESCRIPTION
<!--
Thank you very much for your pull request!
-->

**Description:**
As the commit message says *.es5* files are es5 compatible. Tested with https://www.npmjs.com/package/es-check.
Please double check as I'm noob with rollup js ;)

Passes all tests

**Related issue (if exists):**
https://github.com/inlet/react-pixi/issues/35