### PR TITLE
🐞 Fixed wrong lifecycle method name

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ class RotatingBunny extends React.Component {
 
   state = { rotation: 0 }
 
-  componenDidMount() {
+  componentDidMount() {
     this.props.app.ticker.add(this.tick)
   }
   
@@ -149,11 +149,11 @@ class RotatingBunny extends React.Component {
     this.props.app.ticker.remove(this.tick)
   }
   
-  tick(delta) {
-    this.setState(({ rotation }) => ({
-      rotation + 0.1 * delta
-    }))
-  }
+  tick = (delta) => {
+      this.setState(({ rotation }) => ({
+          rotation: rotation + 0.1 * delta
+      }))
+  };
   
   render() {
     return <Sprite image="./bunny.png" rotation={this.state.rotation} />

--- a/README.mdx
+++ b/README.mdx
@@ -189,7 +189,7 @@ class RotatingBunny extends React.Component {
 
   state = { rotation: 0 }
 
-  componenDidMount() {
+  componentDidMount() {
     // listen to tick events (raf)
     this.props.app.ticker.add(this.tick)
   }
@@ -199,12 +199,12 @@ class RotatingBunny extends React.Component {
     this.props.app.ticker.remove(this.tick)
   }
   
-  tick(delta) {
-    // rotate this sucker 🙌
-    this.setState(({ rotation }) => ({
-      rotation + 0.1 * delta
-    }))
-  }
+  tick = (delta) => {
+      // rotate this sucker 🙌
+      this.setState(({ rotation }) => ({
+          rotation: rotation + 0.1 * delta
+      }))
+  };
   
   render() {
     return <Sprite image="./bunny.png" rotation={this.state.rotation} />


### PR DESCRIPTION
- componenDidMount -> componentDidMount
- Used ES6 arrow function, since it doesn't create a new context. Therefore, this.setState can be used without binding `this` inside class constructor

<!--
Thank you very much for your pull request!
-->

**Description:**
componenDidMount was missing the `t`. Also doing the classic copy-pasta 🍝 react would crash calling `this.setState of undefined`. Therefore I've replaced the function using the ES6 arrow function.
