### PR TITLE
Clarify renderOnComponentChange documentation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,8 +230,8 @@ Props:
 - `height` the height of the renderers view, default `600`
 - `onMount` a callback function for the created app instance
 - `onUnMount` a callback function when the Stage gets unmounted
-- `raf` use the internal PIXI ticker (requestAnimationFrame), default `true`
-- `renderOnComponentChange` render stage on Stage changes? only useful in combination with `raf`
+- `raf` use the internal PIXI ticker (requestAnimationFrame) to render the stage, default `true`
+- `renderOnComponentChange` render stage when the Stage component updates. This is ignored if `raf` is `true`.
 - `options` see [PIXI.Application options](http://pixijs.download/release/docs/PIXI.Application.html)
 
 The Stage stores the created `PIXI.Application` instance to context, which can be accessed using a [Provider or a Higher 


### PR DESCRIPTION
It seems that `renderOnComponentChange` is an alternative to `raf=true`, and ignored if we render via `requestAnimationFrame`. This was quite confusingly put in the README, and I tried to make it a little bit clearer.