### PR TITLE
Support React Suspense

### DIFF
--- a/src/reconciler/hostconfig.js
+++ b/src/reconciler/hostconfig.js
@@ -113,11 +113,11 @@ export default {
   createInstance: createElement,
 
   hideInstance(instance) {
-    instance.alpha = 0
+    instance.visible = false
   },
 
   unhideInstance(instance) {
-    instance.alpha = 1
+    instance.visible = true
   },
 
   appendInitialChild: appendChild,

--- a/src/reconciler/hostconfig.js
+++ b/src/reconciler/hostconfig.js
@@ -112,6 +112,14 @@ export default {
 
   createInstance: createElement,
 
+  hideInstance(instance) {
+    instance.alpha = 0
+  },
+
+  unhideInstance(instance) {
+    instance.alpha = 1
+  },
+
   appendInitialChild: appendChild,
 
   finalizeInitialChildren(wordElement, type, props) {

--- a/src/reconciler/hostconfig.js
+++ b/src/reconciler/hostconfig.js
@@ -117,7 +117,9 @@ export default {
   },
 
   unhideInstance(instance, props) {
-    instance.visible = props && props.visible !== undefined ? props.visible : true
+    const visible = props !== undefined && props !== null && props.hasOwnProperty('visible') ? props.visible : true
+
+    instance.visible = visible
   },
 
   appendInitialChild: appendChild,

--- a/src/reconciler/hostconfig.js
+++ b/src/reconciler/hostconfig.js
@@ -116,8 +116,8 @@ export default {
     instance.visible = false
   },
 
-  unhideInstance(instance) {
-    instance.visible = true
+  unhideInstance(instance, props) {
+    instance.visible = props && props.visible !== undefined ? props.visible : true
   },
 
   appendInitialChild: appendChild,


### PR DESCRIPTION
Implements `hideInstance` and `unhideInstance` methods for the reconciler so that React Suspense works.

I'm new to both PIXI and the React reconciler, but I referenced how [ReactDOM](https://github.com/facebook/react/blob/796c67a25f980f1bcf9507b9f7d02131b8a2b552/packages/react-dom/src/client/ReactDOMHostConfig.js#L588) implements those methods. I assumed `instance.visible` would be the appropriate property to toggle for a PIXI object, but if there's a better approach please let me know.