### PR TITLE
Allow `PIXI.Application` instance to use `options.view`.

### DIFF
--- a/src/stage/index.js
+++ b/src/stage/index.js
@@ -108,8 +108,8 @@ class Stage extends React.Component {
     const { onMount, width, height, options, raf } = this.props
 
     this.app = new PIXI.Application(width, height, {
-      ...options,
       view: this._canvas,
+      ...options,
     })
 
     this.app.ticker.autoStart = false

--- a/test/stage.spec.js
+++ b/test/stage.spec.js
@@ -66,6 +66,14 @@ describe('stage', () => {
     )
   })
 
+  test('passes options.view to PIXI.Application', () => {
+    const view = document.createElement('canvas')
+    const el = renderer.create(<Stage options={{ view }} />)
+    const app = el.getInstance().app
+
+    expect(app.view).toBe(view)
+  })
+
   test('passes props to canvas element', () => {
     const id = 'stage'
     const className = 'canvas__element'
@@ -278,15 +286,17 @@ describe('stage', () => {
         return <Container />
       }
 
-      const renderStage = (Comp) => (
-        <Stage onMount={_app => { app = _app }}>
-          <Container>{ Comp }</Container>
+      const renderStage = Comp => (
+        <Stage
+          onMount={_app => {
+            app = _app
+          }}
+        >
+          <Container>{Comp}</Container>
         </Stage>
       )
 
-      const render = renderer.create(
-        renderStage()
-      )
+      const render = renderer.create(renderStage())
 
       jest.spyOn(app.ticker, 'add')
       jest.spyOn(app.ticker, 'remove')
@@ -342,11 +352,11 @@ describe('stage', () => {
         const [x, setX] = useState(0)
         useTick(() => setX(x + 1), enabled)
         useLayoutEffect(() => fn(x), [x])
-        
+
         return null
       }
 
-      const renderStage = (enabled) => (
+      const renderStage = enabled => (
         <Stage>
           <Comp enabled={enabled} />
         </Stage>
@@ -355,7 +365,7 @@ describe('stage', () => {
       const el = renderer.create(renderStage(false))
       const instance = el.getInstance().app
 
-      const update = (enabled) => {
+      const update = enabled => {
         // set enabled
         el.update(renderStage(enabled))
 
@@ -377,7 +387,8 @@ describe('stage', () => {
         0, // initial
         1,
         2,
-        3
-      ])})
+        3,
+      ])
+    })
   })
 })

--- a/test/stage.spec.js
+++ b/test/stage.spec.js
@@ -286,17 +286,15 @@ describe('stage', () => {
         return <Container />
       }
 
-      const renderStage = Comp => (
-        <Stage
-          onMount={_app => {
-            app = _app
-          }}
-        >
-          <Container>{Comp}</Container>
+      const renderStage = (Comp) => (
+        <Stage onMount={_app => { app = _app }}>
+          <Container>{ Comp }</Container>
         </Stage>
       )
 
-      const render = renderer.create(renderStage())
+      const render = renderer.create(
+        renderStage()
+      )
 
       jest.spyOn(app.ticker, 'add')
       jest.spyOn(app.ticker, 'remove')
@@ -352,11 +350,11 @@ describe('stage', () => {
         const [x, setX] = useState(0)
         useTick(() => setX(x + 1), enabled)
         useLayoutEffect(() => fn(x), [x])
-
+        
         return null
       }
 
-      const renderStage = enabled => (
+      const renderStage = (enabled) => (
         <Stage>
           <Comp enabled={enabled} />
         </Stage>
@@ -365,7 +363,7 @@ describe('stage', () => {
       const el = renderer.create(renderStage(false))
       const instance = el.getInstance().app
 
-      const update = enabled => {
+      const update = (enabled) => {
         // set enabled
         el.update(renderStage(enabled))
 
@@ -387,8 +385,7 @@ describe('stage', () => {
         0, // initial
         1,
         2,
-        3,
-      ])
-    })
+        3
+      ])})
   })
 })


### PR DESCRIPTION
<!--
Thank you very much for your pull request!
-->

**Description:**

Currently, the `PIXI.Application` instance always uses `this._canvas` as `view`, which is only defined if `options.view` is falsey.  So, while you can pass in something for `options.view`, that won't get hooked up to `PIXI.Application`.