### PR TITLE
switching from canvas prebuilt to canvas & forcing newer jsdom

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "babel-core": "^7.0.0-beta.3",
     "babel-eslint": "^10.0.1",
     "babel-jest": "^24.1.0",
-    "canvas-prebuilt": "1",
+    "canvas": "^2.5.0",
     "cross-env": "^5.2.0",
     "docz": "^0.11.1",
     "eslint": "^5.13.0",
@@ -69,6 +69,7 @@
     "idx": "^2.5.2",
     "if-env": "^1.0.4",
     "jest": "^24.1.0",
+    "jest-environment-jsdom-fourteen": "^0.1.0",
     "lodash": "^4.17.10",
     "pixi.js": "^4.8.5",
     "prettier": "^1.16.4",
@@ -101,6 +102,7 @@
   },
   "jest": {
     "collectCoverage": false,
+    "testEnvironment": "jest-environment-jsdom-fourteen",
     "setupFiles": [
       "./test/bootstrap.js"
     ]


### PR DESCRIPTION

**In order to support PIXI5**

**fixes https://github.com/inlet/react-pixi/issues/98 by replacing canvas-prebuilt with canvas & forcing a newer jsdom on jest**
