### PR TITLE
Add Star component

### DIFF
--- a/src/components/Star.js
+++ b/src/components/Star.js
@@ -1,0 +1,13 @@
+import * as PIXI from 'pixi.js'
+
+const Star = (root, props) => {
+  const { x, y, points, radius, innerRadius, color } = props
+
+  const graphics = new PIXI.Graphics()
+  graphics.beginFill(color)
+  graphics.drawStar(x, y, points, radius, innerRadius)
+
+  return graphics
+}
+
+export default Star

--- a/src/components/Star.mdx
+++ b/src/components/Star.mdx
@@ -1,0 +1,41 @@
+---
+name: Star
+menu: Components
+route: /components/star
+---
+
+import { Playground } from 'docz'
+import Stage from '../stage'
+import { Star } from '../index'
+
+# Star
+
+## Props
+
+http://pixijs.download/v4.8.8/docs/PIXI.Graphics.html#drawStar
+
+## Usage
+
+<Playground>
+  <Stage width={300} height={300} options={{ backgroundColor: 0xeef1f5 }}>
+    <Star
+      color={0x0000FF}
+      radius={8}
+      innerRadius={4}
+      points={6}
+      x={10}
+      y={10}
+    />
+  </Stage>
+</Playground>
+
+## Example
+
+<iframe 
+  height={500} 
+  scrolling="no"
+  title="Sprite"
+  src="//codepen.io/inlet/embed/f68c95780536e31af9678bab19fdd4b5/?height=300&theme-id=33987&default-tab=result&embed-version=2"
+  frameBorder="no"
+  allowFullScreen={true}
+  style={{ width: '100%' }} />

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -8,5 +8,18 @@ import Text from './Text'
 import TilingSprite from './TilingSprite'
 import Mesh from './Mesh'
 import Rope from './Rope'
+import Star from './Star'
 
-export { BitmapText, Container, Graphics, NineSlicePlane, ParticleContainer, Sprite, Text, TilingSprite, Mesh, Rope }
+export {
+  BitmapText,
+  Container,
+  Graphics,
+  NineSlicePlane,
+  ParticleContainer,
+  Sprite,
+  Text,
+  TilingSprite,
+  Mesh,
+  Rope,
+  Star,
+}

--- a/src/index.js
+++ b/src/index.js
@@ -25,3 +25,4 @@ export const Text = TYPES.Text
 export const TilingSprite = TYPES.TilingSprite
 export const Mesh = TYPES.Mesh
 export const Rope = TYPES.Rope
+export const Star = TYPES.Star

--- a/src/utils/element.js
+++ b/src/utils/element.js
@@ -19,6 +19,7 @@ export const TYPES = {
   TilingSprite: 'TilingSprite',
   Mesh: 'Mesh',
   Rope: 'Rope',
+  Star: 'Star',
 }
 
 const ELEMENTS = Object.keys(TYPES).reduce((elements, type) => ({ ...elements, [type]: components[type] }), {})

--- a/test/__snapshots__/element.spec.js.snap
+++ b/test/__snapshots__/element.spec.js.snap
@@ -10,6 +10,7 @@ Object {
   "ParticleContainer": "ParticleContainer",
   "Rope": "Rope",
   "Sprite": "Sprite",
+  "Star": "Star",
   "Text": "Text",
   "TilingSprite": "TilingSprite",
 }

--- a/test/__snapshots__/index.spec.js.snap
+++ b/test/__snapshots__/index.spec.js.snap
@@ -87,6 +87,7 @@ Object {
   "Rope": "Rope",
   "Sprite": "Sprite",
   "Stage": [Function],
+  "Star": "Star",
   "Text": "Text",
   "TilingSprite": "TilingSprite",
   "render": [Function],


### PR DESCRIPTION
**Description:**

Add the new component `Star`, using the [`drawStar`](http://pixijs.download/v4.8.8/docs/PIXI.Graphics.html#drawStar) function.
When we move to Pixi.js 5 we could use [`PIXI.Star`](http://pixijs.download/dev/docs/PIXI.Star.html).

I think that this component is useful, because is a common shape, already there is at PIXI and at others react drawing libraries, such as react-konva.

The code to use at Codepen doc:

```js
const { Stage, Star } = ReactPixi

const App = () => (
  <Stage width={500} height={500} options={{ antialias: true, backgroundColor: 0xeef1f5 }}>
    <Star
      color={0xF1C40F}
      radius={8}
      innerRadius={4}
      points={6}
      x={10}
      y={10}
    />
  </Stage>
)

ReactDOM.render(<App />, document.body)
```