### PR TITLE
Expose applyDefaultProps

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -4,6 +4,7 @@ import Stage from './stage'
 import { PixiFiber } from './reconciler'
 import { Context as AppContext, AppProvider, AppConsumer, withPixiApp } from './stage/provider'
 import { useTick, useApp } from './hooks'
+import { applyDefaultProps } from './utils/props';
 
 /**
  * -------------------------------------------
@@ -14,6 +15,7 @@ import { useTick, useApp } from './hooks'
 export { render, Stage, withPixiApp, PixiComponent, PixiFiber }
 export { AppProvider, AppConsumer, AppContext }
 export { useTick, useApp }
+export { applyDefaultProps }
 
 export const BitmapText = TYPES.BitmapText
 export const Container = TYPES.Container


### PR DESCRIPTION
When creating a custom component (for example, Sprite2D from [pixi-projection](https://github.com/pixijs/pixi-projection)), it would be very handy to use applyDefaultProps to apply all the common DisplayObject properties, instead of manually having to apply them again.