### PR TITLE
Change: Inject React-DOM version to React DevTools

### DIFF
--- a/src/reconciler/index.js
+++ b/src/reconciler/index.js
@@ -4,4 +4,5 @@ import hostconfig from './hostconfig'
 
 export const PixiFiber = Reconciler(hostconfig)
 export const VERSION = pkg.version
+export const REACT_DOM_VERSION = pkg.devDependencies['react-dom'].replace(/[^0-9.]/g, '')
 export const PACKAGE_NAME = pkg.name

--- a/src/render/index.js
+++ b/src/render/index.js
@@ -1,6 +1,6 @@
 import invariant from 'fbjs/lib/invariant'
 import { Container } from 'pixi.js'
-import { PixiFiber, PACKAGE_NAME, VERSION } from '../reconciler'
+import { PixiFiber, PACKAGE_NAME, REACT_DOM_VERSION } from '../reconciler'
 
 // cache root containers
 export const roots = new Map()
@@ -42,7 +42,7 @@ export function render(element, container, callback = undefined) {
 export function injectDevtools() {
   PixiFiber.injectIntoDevTools({
     bundleType: process.env.NODE_ENV !== 'production' ? 1 : 0,
-    version: VERSION,
+    version: REACT_DOM_VERSION,
     rendererPackageName: PACKAGE_NAME,
     findHostInstanceByFiber: PixiFiber.findHostInstance,
   })


### PR DESCRIPTION
React DevTools needs to receive the React-DOM version instead of the react-pixi version in order to work.

Once this is updated, you can test with the following code:

Codesandbox: https://xk3d2.csb.app/
Codesandbox source: https://codesandbox.io/s/react-pixi-with-ref-example-xk3d2

This is the solution proposed after discussing it here: https://github.com/facebook/react/issues/16666