### PR TITLE
ts: missing pointlike for sprite's Anchor prop

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -73,7 +73,7 @@ declare namespace _ReactPixi {
     > &
     InteractionEvents;
 
-  type ISprite = Container<PIXI.Sprite> & WithSource;
+  type ISprite = WithPointLike<Container<PIXI.Sprite>, 'anchor'> & WithSource;
   type IText = WithPointLike<Container<PIXI.Text>, 'anchor'>;
   type IContainer = Container<PIXI.Container>;
   type IGraphics = Container<PIXI.Graphics> & {


### PR DESCRIPTION
<!--
Thank you very much for your pull request!
-->

**Description:**
After a refactorization over ts def in [this pr](https://github.com/inlet/react-pixi/commit/d75f60d68a7ca67c14b9fab20bf2ed3ea4bc0118#diff-b52768974e6bc0faccb7d4b75b162c99), the Sprite object is not augmented with pointlike type for anchor prop of Sprite.

**Related issue (if exists):**
