### PR TITLE
Fix syntax error in index.d.ts

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -393,4 +393,4 @@ export const applyDefaultProps: <P extends object>(
  */
 export const withFilters: <T extends { [key: string]: any }>(
     WrappedComponent: React.ComponentType, filters?: Array<any>
-) => React.ComponentClass<Omit<Partial<T>, 'children'>;
+) => React.ComponentClass<Omit<Partial<T>, 'children'>>;


### PR DESCRIPTION
<!--
Thank you very much for your pull request!
-->

**Description:**
Missing closing `>` causes a syntax error.