### PR TITLE
Support of css classes and styled components (beta)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ examples/
 .docz/
 .yarn-error.log
 docs/
+coverage/

--- a/className.mdx
+++ b/className.mdx
@@ -1,0 +1,296 @@
+---
+name: 'ClassName'
+route: '/className'
+menu: CSS Support (Beta)
+---
+
+# className attribute
+
+With the introduction of the className attribute react-pixi supports the use of css files to style pixi components almost in the same way as you would do it for React HTML elements, which means that most of the PIXI properties can be defined in your own class selectors. Names of the class selectors need to be preceded by 'pixi'.
+
+```css
+pixi.header {
+  x: 0;
+  y: 0;
+  alpha: 0.8;
+}
+
+ pixi.title {
+  fontFamily: Arial;
+  font-size: 36;
+  font-style: italic; // both the pixi camel cased and css kebab cased style are supported
+  fontWeight: bold;
+  fill: ['#FF0000', '#FFFF00'];
+  stroke: #FFFFFF;
+  strokeThickness: 5;
+  dropShadow: true;
+  dropShadowColor: #000000;
+  dropShadowBlur: 4;
+  dropShadowDistance: 6;
+  wordWrap: true;
+  wordWrapWidth: 400;
+}
+
+pixi.clickable {
+  alpha: 0.8;
+  buttonMode: true;
+}
+
+// comma to separate multiple selectors with the same styles.
+pixi.hidden, .hide {
+  alpha: 0;
+}
+
+// same declarations get merged, and same rules override each other meaning that the last one wins
+
+pixi.clickable {
+  alpha: 1;
+  interactive: true;
+}
+```
+
+Then on your React component you could use them as follow: 
+
+```js
+  <Container className='header'>
+    <Text className='title' text='Welcome' />
+  </Container>
+
+```
+
+or with the very convenient [classNames](https://github.com/JedWatson/classnames) library.
+
+```js
+  const btnClass = classNames({
+      clickable: clickable,
+      btn: true
+  });
+   <Container className={btnClass}>
+```
+
+
+Stylesheets can be imported directly in your component as usual (in this case you'll need to install `css-loader` and `style-loader` if you use a webpack build), as internal by using the `<style>` tag in the head, or even as an external stylesheet added as a link to the HTML main document (as long as the .css file is on the same domain of the html that loads it).
+
+
+## Properties inside sub-objects
+
+There are some properties that are inside sub-objects in PIXI, such as `.object.position.x`, `object.scale.y`, `object.skew.x`, and which are often used. In CSS, in order to be able to parse them you have to use the much easier format: `positionX`, `positionY`, `scaleX`, `scaleY`.
+Other properties affected are `skew`,`pivot`,`anchor`,`tilePosition` and `tileScale`.
+
+Note also that `rotation` can be written in degress, not in radians.
+
+## !important rule
+
+Same as Dom CSS, inline set props have the priority over the ones defined on the stylesheet, unless they contain the `!important` clause, in this case they would override it.
+
+```css
+pixi.header {
+  x: 0;
+  y: 0;
+  ..
+  alpha: 0.8 !important;
+}
+```
+
+```js
+  //alpha will be overriden onl
+  <Container x={10} y={10} alpha={1}>
+```
+
+## Media queries
+
+To use different rules for different devices mediaqueries are also supported
+
+
+```css
+
+@media (min-width: 1024px) {
+  pixi.header {
+    visible: false;
+  }
+}
+```
+
+## CSS Animations
+
+Very conveniently you can also define animations for your PIXI components with CSS. This feature requires the use of [gsap](https://greensock.com/gsap/) as a project dependency.
+
+
+```css
+@keyframes fromtoptobottom {
+  from {
+    y: 0;
+  }
+  to {
+    y: 590;
+  }
+}
+
+@keyframes aroundthescreen {
+  0% {
+    x:0;
+  }
+  25% {
+    x: 400;
+  }
+  50% {
+    y: 400;
+  }
+  75% {
+    x: 0;
+  }
+  100% {
+    y: 0;
+  }
+}
+
+
+pixi.from-top-to-bottom {
+  animation-name: fromtoptobottom;
+  animation-duration: 1000;
+  animation-delay: 1000;
+}
+
+pixi.around-the-screen {
+  animation-name: aroundthescreen;
+  animation-duration: 2000;
+  animation-delay: 2000;
+}
+
+```
+
+
+### 'animationEnd' event
+
+All components that use a class that is triggering a css animation call an `animationEnd` event once the animation has finished. This is true also for the classes that have `animation-direction` set as 'reverse', whereas the ones with `animation-iteration-count` set as 'infinite' never call `animationEnd`
+
+
+```js
+  <Container className='around-the-screen' animationEnd={this.handleAnimationEnd} />
+```
+
+
+### Differences with actual CSS animations
+
+- The `animation` shorthand property is currently not supported, therefore each animation params need to be declared with its own property.
+- Almost all animation parameters are supported, with the exception of the `animation-fill-mode` which is currently ignored and behaves as it would do if set as `forwards`.
+- Durations can be currently set only by using milliseconds, therefore css time format (2ms, 1s...) is not currently supported.
+- To set the `animation-timing-function` refer to https://greensock.com/ease-visualizer/ as the Dom CSS predefined ones won't work. Example of valid values would be `animation-timing-function: Power1.easeOut` or `Elastic.easeIn` 
+
+
+## CSS Transitions
+
+Together with CSS animations, also CSS transitions can be used.
+
+```css
+pixi.movable {
+ transition-property: x, y;
+ transition-duration: 1000;
+ transition-timing-function: Circ.easeIn;
+ x: 0;
+}
+
+pixi.moving {
+ x: 500;
+ y: 550;
+}
+
+```
+
+
+In the same way as Dom CSS, also on react-pixi the element first needs to be set with the class that declares the transition properties, and then any ensuing other class that will be added and that will change the values of those properties will unleash the animations. 
+
+
+### 'transitionEnd' event
+
+Same as Dom CSS animations, also components that are animated with transitions call a `transitionEnd` event once the animation has finished.
+
+
+```js
+  <Container className='around-the-screen' animationEnd={this.handleAnimationEnd} />
+```
+
+
+### Differences with actual CSS transitions
+
+- The `transition` shorthand property is currently not supported, therefore each transition params need to be declared with its own property.
+- Durations can be currently set only by using milliseconds, therefore css time format (2ms, 1s...) is not currently supported.
+- To set the `transition-timing-function` refer to https://greensock.com/ease-visualizer/ as the css predefined ones won't work. Example of valid values would be `transition-timing-function: Power1.easeOut` or `Elastic.easeIn` 
+
+## getCSSBasedProps
+
+`getCSSBasedProps` is a useful method that returns an object literal with all css properties that the className attribute has set. This allows to use the props in a more imperative way when needed. Examples of that is when using the `ref` attribute, or when setting the rules for the drawing API in the `Graphics` component such as follows.
+
+
+```css
+pixi.header {
+  width: 1024;
+  height: 100;
+  background-color: 0x555555;
+  z-index: 2;
+  x: 0;
+  y: 0;
+}
+```
+
+
+```js
+<Graphics className={'header'} draw={(graphics) => {
+  const props = graphics.getCSSBasedProps()
+  const {backgroundColor, x, y, width, height} = props
+  graphics.beginFill(backgroundColor);
+  graphics.drawRect(x, y, width, height);
+  graphics.endFill();
+}} />
+
+```
+
+## What is not supported (Yet)
+
+The supports of the className attributes comes with a huge set of css feature immediately available, which will make the writing your PIXI application with React even more declarative, and many more are on the roadmap. But right now, of course, as the Dom CSS native implementation is huge, and not all of it is useful for the kind of applications that are built with PIXI, many of them are missing. Besides, as react-pixi supports also 'styled-components', it is already easy to write components with a great level of style encapsulation. 
+
+Following some Dom CSS features that are currently incomplete, different or totally missing.
+
+### COMBINING SELECTORS
+
+Currently the only selector supported, other than the **single class** one used in all examples above, is the **compounding multiple class selector**, meaning that you can also define your selector in this way:
+
+```css
+pixi.header.desktop {
+  width: 1024;
+  height: 100;
+  background-color: 0x555555;
+  z-index: 2;
+  x: 0;
+  y: 0;
+}
+
+pixi.title {
+   fontFamily: Arial;
+   font-size: 36;
+}
+
+pixi.white {
+   fill: '#FFFFFF';
+}
+
+```
+
+and then use them like this
+
+```js
+  <Container className='header desktop'>
+    <Text className='title white' text='Welcome' />
+  </Container>
+
+```
+
+Therefore all the other combining css selectors, such as **descendant, next sibling, etc.** are not supported. Also selecting by ID, or with pseudo selectors such us `:hover` is not yet offered.  
+
+### SPECIFICITY
+
+CSS specificity between rules is not yet leveraged, therefore all CSS rules are interpreted with the same level of importance. The only levels of specificity which apply are: 
+
+- inline attributes prevail over the ones set with css classes
+- `!important` prevail over the inline set attributes
+- classes triggered by mediaquery matching prevail over the general ones, regardless of the `!important` clause.

--- a/package.json
+++ b/package.json
@@ -95,7 +95,8 @@
     "pixi.js": "^5.x.x",
     "prop-types": "^15.x.x",
     "react": "^16.x.x",
-    "react-dom": "^16.x.x"
+    "react-dom": "^16.x.x",
+    "gsap": "^2.x.x"
   },
   "dependencies": {
     "@testing-library/react": "8.0.5",

--- a/src/cssManager/cssManager.js
+++ b/src/cssManager/cssManager.js
@@ -1,0 +1,174 @@
+import {
+  getToBeTweenedProps,
+  convertCSSPropsToPIXI,
+  getContexts,
+  transitionPropertyNames,
+  animationPropertyNames,
+  textStylePropertiesNames,
+} from '../utils/css'
+import { convertAnimationToTween, convertTransitionToTween } from './tweens'
+import cssSource from './cssSource'
+import { unassign, pick, isEmpty, splitAndTrim } from '../helpers'
+
+const filterTweenPropsAndParams = (props, toRemove, action) => {
+  const filter = {
+    in: pick,
+    out: unassign,
+  }
+  const transitionProps = props.transitionProperty
+  const propsHandledByTransition = Object.keys(toRemove)
+
+  return filter[action](props, [...propsHandledByTransition, ...transitionPropertyNames, ...animationPropertyNames])
+}
+
+const getCSSBasedProps = cssRule => {
+  const props = {
+    style: {},
+  }
+
+  Object.keys(cssRule).forEach(rule => {
+    if (textStylePropertiesNames.includes(rule)) {
+      props.style[rule] = cssRule[rule]
+    } else {
+      props[rule] = cssRule[rule]
+    }
+  })
+  return props
+}
+
+const extendPIXIWithCSSProps = (cssProps, props = {}) => {
+  const elProps = convertCSSPropsToPIXI(cssProps)
+  const importantElProps = convertCSSPropsToPIXI(cssProps, true)
+  return {
+    ...elProps,
+    ...props,
+    ...importantElProps,
+    style: {
+      ...elProps.style,
+      ...props.style,
+      ...importantElProps.style,
+    },
+  }
+}
+
+const getInitialElementProp = (element, cssBasedProp) => {
+  let value
+  if (isEmpty(element[cssBasedProp])) {
+    const context = getContexts()[cssBasedProp]
+    if (context) {
+      const axis =
+        cssBasedProp
+          .charAt(cssBasedProp.length - 1)
+          .toLowerCase()
+          .indexOf('x') !== -1
+          ? 'x'
+          : 'y'
+      value = element[context][axis]
+    } else {
+      value = element[cssBasedProp]
+    }
+  } else {
+    value = element[cssBasedProp]
+  }
+  return value
+}
+
+export default (element, type, applyProps) => {
+  const initialCSSValues = {}
+  let allProps
+  let currentClassName
+  let currentProps = {}
+  let transitionProps = {}
+  element.getCSSBasedProps = () => {
+    return extendPIXIWithCSSProps(getCSSBasedProps(cssSource.getCSSRuleByName(currentClassName)))
+  }
+  const tweenComponent = (animationProps, animationParams) => {
+    const { transitionProperty, animationName } = animationParams
+    const arrTransitionProps = Object.keys(transitionProps)
+    if (animationName) {
+      const animationByName = cssSource.getCSSAnimationByName(animationName)
+      if (animationByName) {
+        convertAnimationToTween(element, animationByName, animationParams)
+      }
+    }
+    if (arrTransitionProps.length > 0) {
+      convertTransitionToTween(element, pick(animationProps, arrTransitionProps), animationParams)
+    }
+
+    if (transitionProperty) {
+      transitionProperty.split(',').forEach(p => {
+        transitionProps[p.trim()] = true
+      })
+    }
+  }
+
+  const setCSSProps = (className, isUpdate, props) => {
+    let animationProps
+    let animationParams
+    if (className) {
+      if (!isUpdate && currentProps.styled) {
+        const styledComponentCSSSelector = className.split(' ')
+        currentClassName = styledComponentCSSSelector[styledComponentCSSSelector.length - 1]
+        cssSource.addStyleSheet(document.querySelectorAll('[data-styled]')[0].innerHTML, currentClassName)
+      } else {
+        currentClassName = className
+      }
+    } else {
+      transitionProps = {}
+    }
+
+    const cssBasedProps = getCSSBasedProps(cssSource.getCSSRuleByName(className))
+    Object.keys(cssBasedProps).forEach(cssBasedProp => {
+      if (isEmpty(initialCSSValues[cssBasedProp])) {
+        initialCSSValues[cssBasedProp] = getInitialElementProp(element, cssBasedProp)
+      }
+    })
+
+    allProps = {
+      ...initialCSSValues,
+      ...extendPIXIWithCSSProps(cssBasedProps, props),
+    }
+
+    animationProps = {
+      ...initialCSSValues,
+      ...filterTweenPropsAndParams(allProps, transitionProps, 'in'),
+    }
+
+    animationParams = getToBeTweenedProps(animationProps)
+    const { transitionProperty } = animationParams
+    if (!transitionProperty) {
+      transitionProps = {}
+    }
+
+    const propsAndParamsWithoutTweened = filterTweenPropsAndParams(allProps, transitionProps, 'out')
+    tweenComponent(animationProps, animationParams)
+
+    return propsAndParamsWithoutTweened
+  }
+
+  const updateComponent = () => {
+    if (!cssSource.hasMediaQuery(`.${currentClassName}`)) return
+    setCSSProps(currentClassName, true)
+
+    if (applyProps) {
+      applyProps(element, currentProps, filterTweenPropsAndParams(allProps, transitionProps, 'out'))
+    }
+  }
+
+  const setProps = props => {
+    currentProps = props
+  }
+
+  cssSource.addMediaQueryListener(updateComponent)
+
+  element.on('removed', () => {
+    //clean up when element is removed by the stage
+    delete element.cssManager
+    cssSource.removeMediaQueryListener(updateComponent)
+  })
+
+  return {
+    setCSSProps,
+    setProps,
+  }
+}

--- a/src/cssManager/cssSource.js
+++ b/src/cssManager/cssSource.js
@@ -1,0 +1,150 @@
+import { parseCSSInnerHTML, getAtRules, parseAnimationRule, cssRuleMatch, hasCSSAnimations } from '../utils/css'
+import { sortProps, deepmerge } from '../helpers'
+
+const cssAnimations = {}
+let cssRules = {}
+const mediaqueries = {}
+const selectorsWithMediaQueries = []
+const mediaqueriesListeners = []
+const mediaqueriesMatchers = []
+
+const canITween = cssRule => {
+  if (hasCSSAnimations(cssRule) && !window.TimelineMax) {
+    console.error('GSAP needs to be a project dependency if you want to use css animations or transitions')
+    return false
+  }
+  return true
+}
+
+const sortRulesWithTransitionsPropsFirst = (rule1, rule2) => {
+  const rule1Props = Object.keys(rule1[1])
+  const rule2Props = Object.keys(rule2[1])
+  return rule2Props.includes('transitionProperty') - rule1Props.includes('transitionProperty')
+}
+
+const callMediaqueryListeners = value => {
+  const mq = value.media.replace(/\s+/g, '').trim()
+  if (!mediaqueries[mq]) return
+  const isCurrentlyMatching = mediaqueries[mq].matching
+  mediaqueries[mq].matching = value.matches
+  mediaqueriesListeners.forEach(listener => {
+    if (isCurrentlyMatching !== mediaqueries[mq].matching) {
+      listener.call(listener, value.matches)
+    }
+  })
+}
+
+const extendWithDictionary = (obj, dictionary) => {
+  Object.keys(dictionary).forEach(prop => {
+    if (!obj[prop]) {
+      obj[prop] = dictionary[prop]
+    } else {
+      obj[prop] = {
+        ...obj[prop],
+        ...dictionary[prop],
+      }
+    }
+  })
+}
+
+const getMatchingMediaQueries = () => {
+  const matchingMediaQueries = {}
+  Object.keys(mediaqueries)
+    .filter(mediaquery => mediaqueries[mediaquery].matching === true)
+    .map(mediaquery => mediaqueries[mediaquery].cssRules)
+    .forEach(rules => {
+      extendWithDictionary(matchingMediaQueries, rules)
+    })
+  return matchingMediaQueries
+}
+
+const addStyleSheet = (cssInnerHTML, specificRule) => {
+  if (specificRule && cssRules[`.${specificRule}`]) return
+  const cssRule = parseCSSInnerHTML(cssInnerHTML, specificRule || 'rules')
+  if (canITween(cssRule)) {
+    extendWithDictionary(cssRules, cssRule)
+  }
+
+  getAtRules(cssInnerHTML, 'media').forEach(rule => {
+    const cssRulesInMediaQuery = parseCSSInnerHTML(rule.content, specificRule || 'rules')
+
+    if (!mediaqueries[rule.rule]) {
+      mediaqueries[rule.rule] = {
+        cssRules: cssRulesInMediaQuery,
+        matching: false,
+      }
+      const mediaquery = window.matchMedia(rule.rule)
+      mediaqueriesMatchers.push(mediaquery)
+      callMediaqueryListeners(mediaquery)
+      mediaquery.addListener(callMediaqueryListeners)
+    } else {
+      extendWithDictionary(mediaqueries[rule.rule].cssRules, cssRulesInMediaQuery)
+    }
+    Object.keys(cssRulesInMediaQuery).forEach(r => {
+      if (canITween(cssRulesInMediaQuery[r])) {
+        selectorsWithMediaQueries.push(r)
+      }
+    })
+  })
+
+  if (window.TimelineMax) {
+    getAtRules(cssInnerHTML, 'keyframes').forEach(atRule => {
+      const animationRule = parseAnimationRule(atRule)
+      cssAnimations[atRule.rule] = animationRule
+    })
+  }
+  //make rules containing transition-property declarations always being found first
+  cssRules = sortProps(cssRules, sortRulesWithTransitionsPropsFirst)
+}
+
+const getCSSRuleByName = name => {
+  let obj = {}
+  const cssRulesInMediaQueries = getMatchingMediaQueries()
+  const allCSSRules = deepmerge({}, [cssRules, cssRulesInMediaQueries])
+
+  Object.keys(allCSSRules)
+    .filter(cssRule => cssRuleMatch(cssRule.replace(/\s/g, ''), name))
+    .forEach(cssRule => {
+      obj = { ...obj, ...allCSSRules[cssRule] }
+    })
+  return obj
+}
+
+const addMediaQueryListener = listener => {
+  mediaqueriesListeners.push(listener)
+  mediaqueriesMatchers.forEach(value => {
+    listener.call(listener, value.matches)
+  })
+}
+
+const removeMediaQueryListener = listener => {
+  const index = mediaqueriesListeners.indexOf(listener)
+  if (index > -1) {
+    mediaqueriesListeners.splice(index, 1)
+  }
+}
+
+const getCSSAnimationByName = name => cssAnimations[name]
+
+const hasMediaQuery = selector => selectorsWithMediaQueries.includes(selector)
+
+const addStyleSheets = styleSheets => {
+  Array.from(styleSheets).forEach(styleSheet => {
+    const cssInnerHTML = styleSheet.ownerNode.innerHTML
+    addStyleSheet(cssInnerHTML, null)
+  })
+}
+
+const cssSource = {
+  hasMediaQuery,
+  addStyleSheets,
+  addStyleSheet,
+  getCSSAnimationByName,
+  getCSSRuleByName,
+  addMediaQueryListener,
+  removeMediaQueryListener,
+}
+
+Object.freeze(cssSource)
+
+export default cssSource

--- a/src/cssManager/tweens.js
+++ b/src/cssManager/tweens.js
@@ -1,0 +1,82 @@
+import { pick, isFunction } from '../helpers'
+
+export const convertAnimationToTween = (
+  element,
+  props,
+  {
+    animationDuration = 1,
+    animationDelay = 1,
+    animationIterationCount = 1,
+    animationDirection = 'normal',
+    animationTimingFunction = 'linear',
+    animationFillMode,
+    animationPlayState = 'running',
+  }
+) => {
+  if (!window.TimelineMax) return false
+  const animationsTimeline = new window.TimelineMax({
+    paused: animationPlayState === 'paused',
+    delay: animationDelay / 1000,
+    yoyo: animationDirection === 'alternate',
+    repeat: animationIterationCount !== 'infinite' ? animationIterationCount - 1 : -1,
+    onReverseComplete: () => {
+      if (element.animationEnd && isFunction(element.animationEnd) && animationDirection === 'reverse') {
+        element.animationEnd.call(element, element)
+      }
+      animationsTimeline.kill()
+    },
+    onComplete: () => {
+      if (element.animationEnd && isFunction(element.animationEnd)) {
+        element.animationEnd.call(element, element)
+      }
+      animationsTimeline.kill()
+    },
+  })
+
+  if (animationDirection === 'reverse' && animationPlayState === 'running') {
+    animationsTimeline.reverse(0, false)
+  }
+
+  Object.keys(props.steps).forEach((step, index, arr) => {
+    let time = 0
+    if (index >= 1) {
+      time = parseFloat(arr[index]) - parseFloat(arr[index - 1])
+    }
+    animationsTimeline.to(element, (time / 100) * (animationDuration / 1000), {
+      ease: animationTimingFunction,
+      pixi: { ...props.steps[step] },
+    })
+  })
+  return animationsTimeline
+}
+
+export const convertTransitionToTween = (
+  element,
+  baseProps,
+  { transitionProperty, transitionDuration = 0, transitionDelay = 0, transitionTimingFunction = 'linear' }
+) => {
+  if (!window.TimelineMax) return false
+  const transitionPropNames = transitionProperty ? transitionProperty.split(',').map(item => item.trim()) : []
+
+  const propsToTransition = pick(baseProps, transitionPropNames)
+  if (Object.entries(propsToTransition).length > 0) {
+    const transition = new window.TimelineMax({
+      delay: transitionDelay / 1000,
+      ease: transitionTimingFunction,
+      onComplete: () => {
+        transition.kill()
+        if (element.transitionEnd && isFunction(element.transitionEnd)) {
+          element.transitionEnd.call(element, element)
+        }
+      },
+    })
+
+    transition.to(element, transitionDuration / 1000, {
+      ease: transitionTimingFunction,
+      pixi: propsToTransition,
+    })
+
+    return transition
+  }
+  return false
+}

--- a/src/helpers/index.js
+++ b/src/helpers/index.js
@@ -1,4 +1,10 @@
+const _DEG2RAD = Math.PI / 180
+
 export const isFunction = (...args) => args.every(v => typeof v === 'function')
+
+export const isEmpty = value => {
+  return typeof value === 'undefined' || value === null
+}
 
 export const isObject = obj => Object.prototype.toString.call(obj) === '[object Object]'
 
@@ -25,6 +31,105 @@ export const not = boolFn => (...args) => !boolFn(...args)
 
 export const runningInBrowser = () => typeof window !== 'undefined'
 
+export const unassign = (obj, keys) => {
+  const target = Object.assign({}, obj)
+  keys.forEach(key => {
+    delete target[key]
+  })
+  return target
+}
+
+export const pick = (obj, keys) => {
+  var res = {}
+  if (typeof keys === 'string') {
+    if (keys in obj) {
+      res[keys] = obj[keys]
+    }
+    return res
+  }
+
+  var len = keys.length
+  var idx = -1
+
+  while (++idx < len) {
+    var key = keys[idx]
+    if (key in obj) {
+      res[key] = obj[key]
+    }
+  }
+  return res
+}
+
+export const degreesToRadians = value => {
+  return typeof value === 'string' && value.charAt(1) === '='
+    ? value.substr(0, 2) + parseFloat(value.substr(2)) * _DEG2RAD
+    : value * _DEG2RAD
+}
+
+export const splitAndTrim = (string, separator) => {
+  return string
+    ? string.split(separator).map(item => {
+        return item.trim()
+      })
+    : []
+}
+
+export const isBooleanString = value => {
+  return value === 'true' || value === 'false'
+}
+
+export const convertToCamelCased = value => {
+  return value.replace(/-([a-z])/g, g => {
+    return g[1].toUpperCase()
+  })
+}
+
+export const containsAny = (selectorText, ors) => {
+  return selectorText ? ors.some(x => selectorText.indexOf(x) >= 0) : false
+}
+
+export const containsAll = (selectorText, ors) => {
+  return selectorText ? ors.every(x => selectorText.indexOf(x) >= 0) : false
+}
+
 export const lcFirst = value => {
   return value.charAt(0).toLowerCase() + value.substring(1)
+}
+
+export const sortProps = (obj, fn) => {
+  return Object.entries(obj)
+    .sort(fn)
+    .reduce(
+      (_sortedObj, [k, v]) => ({
+        ..._sortedObj,
+        [k]: v,
+      }),
+      {}
+    )
+}
+
+const mergeValues = (target, source) => {
+  if (isObject(target) && isObject(source)) {
+    return mergeObjects(target, source)
+  }
+  if (source === undefined) {
+    return target
+  }
+  return source
+}
+
+const mergeObjects = (target, source) => {
+  Object.keys(source).forEach(key => {
+    const sourceValue = source[key]
+    const targetValue = target[key]
+    target[key] = mergeValues(targetValue, sourceValue)
+  })
+  return target
+}
+
+export const deepmerge = (target, sources) => {
+  sources.forEach(source => {
+    return mergeValues(target, source)
+  })
+  return target
 }

--- a/src/hoc/withFilters.js
+++ b/src/hoc/withFilters.js
@@ -1,6 +1,5 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import { Filter as PixiFilter } from 'pixi.js'
 import { isFunction, lcFirst } from '../helpers'
 
 export const withFilters = (WrappedComponent, filters) => {

--- a/src/reconciler/hostconfig.js
+++ b/src/reconciler/hostconfig.js
@@ -9,8 +9,8 @@
  */
 
 import invariant from 'fbjs/lib/invariant'
+import cssManager from '../cssManager/cssManager'
 import performanceNow from 'performance-now'
-
 import { createElement } from '../utils/element'
 import { CHILDREN, applyDefaultProps } from '../utils/props'
 
@@ -196,12 +196,22 @@ export default {
 
   insertInContainerBefore: insertBefore,
 
-  commitUpdate(instance, updatePayload, type, oldProps, newProps) {
+  commitUpdate(instance, updatePayload, type, oldProps, { className, ...newProps }) {
     let applyProps = instance && instance.applyProps
+    let cssProps
+    let cssMan = instance.cssManager
+    if (className && !cssMan) {
+      cssMan = cssManager(instance, type, applyDefaultProps)
+      instance.cssManager = cssMan
+    }
     if (typeof applyProps !== 'function') {
       applyProps = applyDefaultProps
     }
-    applyProps(instance, oldProps, newProps)
+    if (cssMan) {
+      cssMan.setProps(newProps)
+      cssProps = cssMan.setCSSProps(className, true, newProps)
+    }
+    applyProps(instance, oldProps, cssMan ? cssProps : newProps)
   },
 
   commitMount(instance, updatePayload, type, oldProps, newProps) {

--- a/src/stage/index.js
+++ b/src/stage/index.js
@@ -2,6 +2,7 @@ import React from 'react'
 import { Application } from 'pixi.js'
 import PropTypes from 'prop-types'
 import invariant from 'fbjs/lib/invariant'
+import cssSource from '../cssManager/cssSource'
 import { PROPS_DISPLAY_OBJECT } from '../utils/props'
 import { runningInBrowser } from '../helpers'
 import { PixiFiber } from '../reconciler'
@@ -106,7 +107,7 @@ class Stage extends React.Component {
 
   componentDidMount() {
     const { onMount, width, height, options, raf } = this.props
-
+    cssSource.addStyleSheets(document.styleSheets)
     this.app = new Application({
       width,
       height,

--- a/src/utils/css.js
+++ b/src/utils/css.js
@@ -1,0 +1,197 @@
+import { isEmpty, splitAndTrim, isBooleanString, convertToCamelCased, containsAll } from '../helpers'
+
+export const transitionPropertyNames = [
+  'transitionProperty',
+  'transitionDuration',
+  'transitionDelay',
+  'transitionTimingFunction',
+]
+
+export const animationPropertyNames = [
+  'animationName',
+  'animationDuration',
+  'animationDelay',
+  'animationIterationCount',
+  'animationDirection',
+  'animationTimingFunction',
+  'animationFillMode',
+  'animationPlayState',
+]
+
+export const textStylePropertiesNames = [
+  'align',
+  'breakWords',
+  'dropShadow',
+  'dropShadowAlpha',
+  'dropShadowAngle',
+  'dropShadowBlur',
+  'dropShadowColor',
+  'dropShadowDistance',
+  'fill',
+  'fillGradientType',
+  'fillGradientStops',
+  'fontFamily',
+  'fontSize',
+  'fontStyle',
+  'fontVariant',
+  'fontWeight',
+  'letterSpacing',
+  'lineHeight',
+  'lineJoin',
+  'miterLimit',
+  'padding',
+  'stroke',
+  'strokeThickness',
+  'textBaseline',
+  'trim',
+  'whiteSpace',
+  'wordWrap',
+  'wordWrapWidth',
+  'leading',
+]
+
+const xyContexts = 'position,scale,skew,pivot,anchor,tilePosition,tileScale'.split(',')
+const contexts = {
+  x: 'position',
+  y: 'position',
+  tileX: 'tilePosition',
+  tileY: 'tilePosition',
+}
+
+xyContexts.forEach(xyContext => {
+  contexts[`${xyContext}X`] = xyContext
+  contexts[`${xyContext}Y`] = xyContext
+})
+
+const parseRule = innerHTML => {
+  const ruleRegEx = /\s*([a-z-]+)\s*:\s*((?:[^;]*url\(.*?\)[^;]*|[^;]*)*)\s*(?:;|$)/gi
+  const obj = {}
+  let token
+  while ((token = ruleRegEx.exec(innerHTML))) {
+    obj[convertToCamelCased(token[1])] = token[2]
+  }
+  return obj
+}
+
+export const getContexts = () => contexts
+
+export const castStringCSSValue = value => {
+  if (isEmpty(value)) return false
+  let castValue = value.replace('!important', '').trim()
+  if (castValue.match(/\[[^\]]*]/g) || isBooleanString(castValue)) {
+    castValue = JSON.parse(castValue.replace(/'/g, '"'))
+  } else if (!/\D/.test(castValue)) {
+    castValue = Number(castValue)
+  } else {
+    castValue = castValue.replace(/["']/g, '')
+  }
+  return castValue
+}
+
+export const getToBeTweenedProps = props =>
+  Object.keys(props)
+    .filter(name => name.indexOf('transition') > -1 || name.indexOf('animation') > -1)
+    .reduce((acc, key) => ({ ...acc, [key]: props[key] }), {})
+
+export const convertCSSPropsToPIXI = (props = {}, onlyImportant = false) => {
+  const mainStyle = Object.keys(props)
+    .filter(key => {
+      if (key === 'style') return false
+      const condition = props[key] && props[key].toString().indexOf('!important') > -1
+      return onlyImportant ? condition : !condition
+    })
+    .reduce((acc, key) => ({ ...acc, [key]: castStringCSSValue(props[key]) }), {})
+
+  const txtStyle = props.style
+    ? Object.keys(props.style)
+        .filter(key => {
+          const condition = props.style[key] && props.style[key].toString().indexOf('!important') > -1
+          return onlyImportant ? condition : !condition
+        })
+        .reduce((acc, key) => ({ ...acc, [key]: castStringCSSValue(props.style[key]) }), {})
+    : {}
+
+  return {
+    ...mainStyle,
+    ...{
+      style: txtStyle,
+    },
+  }
+}
+
+export const parseCSSInnerHTML = (innerHTML, type) => {
+  const types = {
+    animation: /([\s\S]+?)\{([\s\S]*?)\}/gi,
+    rules: /pixi([\s\S]+?)\{([\s\S]*?)\}/gi,
+  }
+  let text = innerHTML
+  const ruleRegEx = types[type] || new RegExp(`(.${type}[\\s]*?)\\{([\\s\\S]*?)\\}`, 'gi')
+  const rules = {}
+  let token
+  text = text.replace(/\/\*[\s\S]*?\*\//g, '').replace('-webkit-', '')
+
+  if (type !== 'animation') {
+    text = text.replace(/((@media)([\s\S]*?){([\s\S]*?}\s*?)})/g, '')
+  }
+  while ((token = ruleRegEx.exec(text))) {
+    const style = parseRule(token[2].trim())
+    const classSelectorNames = splitAndTrim(token[1].trim().replace(/\s*,\s*/, ', '), ',')
+
+    classSelectorNames.forEach(classSelectorName => {
+      if (!classSelectorName) {
+        rules[classSelectorName] = style
+      } else {
+        rules[classSelectorName] = {
+          ...rules[classSelectorName],
+          ...style,
+        }
+      }
+    })
+  }
+  return rules
+}
+
+export const parseAnimationRule = innerHTML => {
+  const animation = {
+    steps: {},
+  }
+  const parsedCSS = parseCSSInnerHTML(innerHTML.content, 'animation')
+  Object.keys(parsedCSS).forEach(css => {
+    let selector = css.replace('%', '')
+    if (css === 'from') selector = '0'
+    if (css === 'to') selector = '100'
+    animation.steps[selector] = parsedCSS[css]
+  })
+  return animation
+}
+
+export const getAtRules = (innerHTML, type) => {
+  const ruleRegEx = new RegExp(`((@${type})([\\s\\S]*?){([\\s\\S]*?}\\s*?)})`, 'g')
+  const rules = []
+  let token = ''
+  while ((token = ruleRegEx.exec(innerHTML))) {
+    rules.push({
+      rule: token[3].replace(/\s+/g, '').trim(),
+      content: token[4].trim(),
+    })
+  }
+  return rules
+}
+
+export const cssRuleMatch = (haystack, niddle) => {
+  const haystackArr = splitAndTrim(haystack.substr(1, haystack.length), '.')
+  const niddleArr = splitAndTrim(niddle, ' ')
+  if (haystackArr.length === 1) {
+    return niddleArr.indexOf(haystackArr[0]) > -1
+  }
+  if (haystackArr.length === niddleArr.length) {
+    return containsAll(haystackArr, niddleArr)
+  }
+  return false
+}
+
+export const hasCSSAnimations = obj => {
+  const animationProps = [...transitionPropertyNames, ...animationPropertyNames]
+  const rules = Object.values(obj)
+  return rules.map(rule => animationProps.some(r => Object.keys(rule).includes(r))).includes(true)
+}

--- a/src/utils/element.js
+++ b/src/utils/element.js
@@ -1,6 +1,7 @@
 import invariant from 'fbjs/lib/invariant'
 import idx from 'idx'
 import { applyDefaultProps } from './props'
+import cssManager from '../cssManager/cssManager'
 import * as components from '../components'
 
 /**
@@ -40,12 +41,12 @@ export const TYPES_INJECTED = {}
  * @param {Object} root Root instance
  * @returns {PIXI.*|undefined}
  */
-export function createElement(type, props = {}, root = null) {
+export function createElement(type, { className, ...props } = {}, root = null) {
   const fn = ELEMENTS[type]
-
   let instance
   let applyProps
-
+  let cssProps
+  let cssMan
   if (typeof fn === 'function') {
     instance = fn(root, props)
   }
@@ -63,11 +64,18 @@ export function createElement(type, props = {}, root = null) {
 
   // apply initial props!
   if (instance) {
+    if (className) {
+      cssMan = cssManager(instance, type, applyDefaultProps)
+      instance.cssManager = cssMan
+      cssMan.setProps(props)
+      cssProps = cssMan.setCSSProps(className, null, props)
+    }
     applyProps = idx(instance, _ => _.applyProps)
     if (typeof applyProps !== 'function') {
       applyProps = applyDefaultProps
     }
-    applyProps(instance, {}, props)
+
+    applyProps(instance, {}, className ? cssProps : props)
   }
 
   return instance

--- a/src/utils/pixi.js
+++ b/src/utils/pixi.js
@@ -2,7 +2,8 @@ import { Point, ObservablePoint } from 'pixi.js'
 import invariant from 'fbjs/lib/invariant'
 import idx from 'idx'
 import isNil from 'lodash/isNil'
-
+import { degreesToRadians } from '../helpers'
+import { getContexts } from './css'
 /**
  * Parse PIXI point value to array of coordinates
  *
@@ -106,7 +107,20 @@ export function setValue(instance, prop, value) {
 
     instance[prop].set(coordinates.shift(), coordinates.shift())
   } else {
-    // just hard assign value
-    instance[prop] = value
+    const context = getContexts()[prop]
+    if (context && instance[context]) {
+      const axis =
+        prop
+          .charAt(prop.length - 1)
+          .toLowerCase()
+          .indexOf('x') !== -1
+          ? 'x'
+          : 'y'
+      instance[context][axis] = context === 'skew' ? degreesToRadians(value) : value
+    } else if (prop === 'rotation') {
+      instance[prop] = degreesToRadians(value)
+    } else {
+      instance[prop] = value
+    }
   }
 }

--- a/styledComponents.mdx
+++ b/styledComponents.mdx
@@ -1,0 +1,117 @@
+---
+name: 'Styled Components'
+route: '/styledComponents'
+menu: CSS Support (Beta)
+---
+
+# Styled Components
+
+[styled-components](https://www.styled-components.com/) is increasingly becoming a 'de facto' standard in writing css-in-js React components. The good news is that react-pixi fully supports developing and styling PIXI components using the styled way. All you need to do is to set the `styled` attribute to `true` in order to indicate that you want to use the styled-components library for that component.
+
+```js
+import styled, { keyframes, ThemeProvider } from 'styled-components'
+
+const StyledContainer = styled(Container)`
+    alpha: ${props => props.transparent ? 0.6 : 1};
+`
+
+const StyledText = styled(Text)`
+  fontFamily: Arial;
+  fontSize: 36;
+  fontStyle: italic;
+  fontWeight: bold;
+  fill: ['#FF0000', '#FFFF00'];
+  stroke: #FFFFFF;
+  strokeThickness: 5;
+  dropShadow: true;
+  dropShadowColor: #000000;
+  dropShadowBlur: 4;
+  dropShadowDistance: 6;
+  wordWrap: true;
+  wordWrapWidth: 400;
+`;
+
+
+
+<StyledContainer x={200} styled transparent> 
+    <StyledText x={10} y={10} text="should be at 300,300"  styled /> 
+</StyledContainer>
+
+
+```
+The vast majority of the features are supported, including 
+
+### Mediaqueries
+
+```js
+const MediaQueriedContainer = styled(Container)`
+  @media (min-width: 1024px) {
+    x: 200;
+  }
+`
+```
+
+### Animations
+
+
+```js
+const move = keyframes`
+  from {
+    y: 0
+  }
+  to {
+    alpha: 1;
+    y: 600;
+  }
+`;
+
+
+
+const MovingContainer = styled(Container)`
+     animation-name: ${move};
+     animation-duration: 1000;
+`
+```
+
+
+### Theming
+
+
+```js
+
+const ThemedTitle = styled(Text)`
+  fontFamily: Tahoma;
+  fontSize: ${props => props.theme.fontSize};
+  fontStyle: italic;
+  fontWeight: bold;
+  fill: ${props => props.theme.fill};
+  stroke: #FFFFFF;
+  strokeThickness: 5;
+  dropShadow: true;
+  dropShadowColor: #000000;
+  dropShadowBlur: 4;
+  dropShadowDistance: 6;
+  wordWrap: true;
+  wordWrapWidth: 400;
+`;
+
+
+ThemedTitle.defaultProps = {
+  theme: {
+    fontSize: 36,
+    fill: '#00FF00'
+  }
+}
+
+const theme = {
+  fontSize: 24,
+  fill: '#00FFFF'
+};
+
+ 
+<ThemeProvider theme={theme}>
+  <ThemedTitle x={320} y={400} text="Uses the theme"  styled /> 
+</ThemeProvider>
+
+
+```

--- a/test/__utils__/mock.js
+++ b/test/__utils__/mock.js
@@ -43,3 +43,327 @@ export const getCall = ins => {
   r.fn = ins
   return r
 }
+
+
+export const addTestStyleSheet = function(css) {
+  var style = document.createElement('style');
+  style.id = 'test-stylesheet'
+  style.setAttribute('data-styled', true);
+  style.appendChild(document.createTextNode(css));
+  document.head.appendChild(style);
+
+  return style.sheet;
+};
+
+
+export const removeTestStyleSheet = function() {
+  document.getElementById('test-stylesheet').remove()
+};
+
+
+window.matchMedia = jest.fn().mockImplementation(query => {
+  // (max-width:1024px) will be the mediaquery to use to test the mq matching cases
+  return {
+    matches: query === '(max-width:1024px)' ,
+    media: query,
+    onchange: null,
+    addListener: jest.fn(), 
+    removeListener: jest.fn(), 
+    addEventListener: jest.fn(),
+    removeEventListener: jest.fn(),
+    dispatchEvent: jest.fn(),
+  };
+});
+
+
+export const cssInnerHTML = `
+  /* here put the animations...comments are to test that they don't break stuff */
+  @keyframes slide-bottom {
+    /* starting point of the animation */
+    from {
+      alpha: 0;
+    }
+    to {
+      alpha: 1;
+      y: 590;
+    }
+  }
+
+  /* here all css classes */
+  pixi.x100_y100 {
+    x: 100;
+    y: 100;
+  }
+
+
+  pixi.x100_y100-important {
+    /* important style here */
+    x: 300 !important;
+    y: 500 !important;
+  }
+
+  pixi.yellow {
+    fill: #FFFF00 !important;
+  }
+
+
+  pixi.x400 {
+    x: 400;
+  }
+
+  pixi.rotated {
+    y: 150;
+    rotation: 60;
+  }
+
+  pixi.transition-starting-point {
+   transition-property: x, y;
+   transition-duration: 1000;
+   transition-timing-function: ease-out;
+   x: 0;
+  }
+
+  pixi.transition-animate {
+   x: 500;
+   y: 550;
+  }
+
+  pixi.from-top-to-bottom {
+    animation-name: slide-bottom;
+    alpha: 0;
+    animation-duration: 1000;
+    animation-delay: 1000;
+  }
+
+  pixi.from-top-to-bottom-with-mediaquery {
+    animation-name: slide-bottom;
+    alpha: 0;
+    animation-duration: 1000;
+    animation-delay: 1000;
+  }
+
+  pixi.squared-animation {
+    alpha: 0;
+    animation-name: squared;
+    animation-duration: 2000;
+    animation-delay: 2000;
+  }
+
+  /* check that even when calling animations with same name as classes it won't break stuff */ 
+  pixi.pulsate {
+    alpha: 0;
+    y: 50;
+    animation-name: pulsate;
+    animation-duration: 500;
+    animation-iteration-count: infinite;
+  }
+
+  pixi.clickable {
+    x: 500;
+    y: 700;
+    buttonMode: true;
+    interactive: true;
+  }
+
+  pixi.scalable {
+    y: 650;
+    scaleX: 2;
+    scaleY: 2;
+  }
+
+  pixi.clicked {
+    scaleX: 1.2;
+    scaleY: 1.2;
+  }
+
+  pixi.scalable-animation {
+    y: 850;
+    x: 450;
+    pivotX:0.5;
+    pivotY:0.5;
+    animation-name: pulsate-scale;
+    animation-duration: 500;
+    animation-iteration-count: infinite;
+  }
+
+  .pixi.x200y200 {
+    x: 200;
+  }
+
+  .pixi.x200y200 {
+    y: 200; 
+  }
+
+  .pixi.x300.y300 {
+    x: 300;
+  }
+
+  .pixi.x300.y300 {
+    y: 300; 
+  }
+
+  .pixi.x700 {
+     x: 500;  
+     y: 40;  
+  }
+
+  .pixi.x700 {
+     x: 700;
+  }
+
+  @media (min-width: 1024px) {
+    pixi.from-top-to-bottom {
+      animation-name: slide-bottom;
+      animation-duration: 3000;
+    }
+  }
+
+  @media (max-width: 1024px) {
+    pixi.from-top-to-bottom-with-mediaquery {
+      animation-name: slide-bottom;
+      animation-duration: 3000;
+    }
+  }
+`;
+
+
+
+export const cssObject = {
+  '.clickable': {
+    buttonMode: 'true',
+    interactive: 'true',
+    x: '500',
+    y: '700'
+  },
+  '.clicked': {
+    scaleX: '1.2',
+    scaleY: '1.2'
+  },
+  '.from-top-to-bottom': {
+    alpha: '0',
+    animationDelay: '1000',
+    animationDuration: '1000',
+    animationName: 'slide-bottom'
+  },
+   '.from-top-to-bottom-with-mediaquery': {
+    alpha: '0',
+    animationDelay: '1000',
+    animationDuration: '1000',
+    animationName: 'slide-bottom'
+  },
+  '.x100_y100': {
+    x: '100',
+    y: '100'
+  },
+  '.x100_y100-important': {
+    x: '300 !important',
+    y: '500 !important'
+  },
+  '.pulsate': {
+    alpha: '0',
+    animationDuration: '500',
+    animationIterationCount: 'infinite',
+    animationName: 'pulsate',
+    y: '50'
+  },
+  '.rotated': {
+    rotation: '60',
+    y: '150'
+  },
+  '.scalable': {
+    scaleX: '2',
+    scaleY: '2',
+    y: '650'
+  },
+  '.scalable-animation': {
+    animationDuration: '500',
+    animationIterationCount: 'infinite',
+    animationName: 'pulsate-scale',
+    pivotX: '0.5',
+    pivotY: '0.5',
+    x: '450',
+    y: '850'
+  },
+  '.squared-animation': {
+    alpha: '0',
+    animationDelay: '2000',
+    animationDuration: '2000',
+    animationName: 'squared'
+  },
+  '.transition-animate': {
+    x: '500',
+    y: '550'
+  },
+  '.transition-starting-point': {
+    transitionDuration: '1000',
+    transitionProperty: 'x, y',
+    transitionTimingFunction: 'ease-out',
+    x: '0'
+  },
+  '.x400': {
+    x: '400'
+  },
+  '.yellow': {
+    fill: '#FFFF00 !important'
+  },
+  '.x200y200': {
+    x: '200',
+    y: '200'
+  },
+  '.x300.y300': {
+    x: '300',
+    y: '300'
+  },
+  '.x700': {
+    x: '700',
+    y: '40'
+  }
+};
+
+export const allAnimations = [
+  {
+    content: `/* starting point of the animation */
+    from {
+      alpha: 0;
+    }
+    to {
+      alpha: 1;
+      y: 590;
+    }`,
+    rule: 'slide-bottom'
+  },
+  {
+    content: `0% {
+      alpha: 1;
+      x:0;
+    }
+    25% {
+      x: 400;
+    }
+    50% {
+      y: 400;
+    }
+    75% {
+      x: 0;
+    }
+    100% {
+      y: 0;
+    }`,
+    rule: 'squared'
+  },
+  {
+    content: `0% {
+      alpha: 0;
+    }
+    
+    50% {
+      alpha: 1;
+    }
+
+    100% {
+      alpha: 0;
+    }`,
+    rule: 'pulsate'
+  }
+];
+

--- a/test/css.spec.js
+++ b/test/css.spec.js
@@ -1,0 +1,204 @@
+import {
+  getToBeTweenedProps,
+  convertCSSPropsToPIXI,
+  parseAnimationRule,
+  parseCSSInnerHTML,
+  getAtRules,
+  castStringCSSValue,
+  cssRuleMatch,
+} from '../src/utils/css';
+
+import { cssInnerHTML, cssObject, allAnimations } from './__utils__/mock'
+
+const animationAndTransitionProps = {
+  transitionProperty: 'x',
+  transitionDuration: '1000',
+  transitionDelay: '1000',
+  transitionTimingFunction: 'ease',
+  animationName: 'slidein',
+  animationDuration: '1000',
+  animationDelay: '1000',
+  animationIterationCount: '1',
+  animationDirection: 'reverse',
+  animationTimingFunction: 'ease',
+  animationPlayState: 'running',
+};
+
+const cssProps = {
+  x: '10',
+  y: '10',
+  interactive: 'true',
+  width: '20 !important',
+  style: {
+    fontFamily: 'Arial',
+    fontSize: '36',
+    fontStyle: 'italic',
+    fontWeight: 'bold',
+    fill: '["#FF0000", "#FFFF00"]',
+  },
+};
+
+describe('css', () => {
+  describe('getToBeTweenedProps', () => {
+    let toBeTweenedProps;
+    beforeAll(() => {
+      toBeTweenedProps = {
+        ...animationAndTransitionProps,
+        x: 0,
+        y: 0,
+      };
+    });
+    test('that it should return only props that are related to animations and transitions', () => {
+      expect(getToBeTweenedProps(toBeTweenedProps)).toEqual(
+        animationAndTransitionProps,
+      );
+    });
+  });
+
+  describe('convertCSSPropsToPIXI', () => {
+    test('that should convert the props correctly ', () => {
+      const pixiProps = convertCSSPropsToPIXI(cssProps);
+      expect(pixiProps.x).toEqual(10);
+      expect(pixiProps.interactive).toEqual(true);
+      expect(pixiProps.width).toBeUndefined();
+      expect(pixiProps.style.fill).toEqual(['#FF0000', '#FFFF00']);
+    });
+    test('that should convert the props correctly and return only the !important ones', () => {
+      const pixiProps = convertCSSPropsToPIXI(cssProps, true);
+      expect(pixiProps.x).toBeUndefined();
+      expect(pixiProps.interactive).toBeUndefined();
+      expect(pixiProps.width).toBe(20);
+      expect(pixiProps.style.fill).toBeUndefined();
+    });
+    test('should convert the props correctly and return only all but the !important ones', () => {
+      const pixiProps = convertCSSPropsToPIXI(cssProps, false);
+      expect(pixiProps.x).toEqual(10);
+      expect(pixiProps.interactive).toEqual(true);
+      expect(pixiProps.width).toBeUndefined();
+      expect(pixiProps.style.fill).toEqual(['#FF0000', '#FFFF00']);
+    });
+  });
+
+  describe('parseAnimationRule', () => {
+    test('should convert the animation correctly to an object with its animation steps and name of it', () => {
+      const animationRule = {
+        rule: 'slide-bottom',
+        content:
+          '0% {  alpha: 0;   }   50% {    alpha: 0.5;   y: 200;  } 100% {    alpha: 1;   y: 590;  }',
+      };
+      const animation = parseAnimationRule(animationRule);
+      expect(animation.steps['0']).toEqual({ alpha: '0' });
+      expect(animation.steps['50']).toEqual({ alpha: '0.5', y: '200' });
+      expect(animation.steps['100']).toEqual({ alpha: '1', y: '590' });
+    });
+    test('should convert the animation correctly interpreting "from" as 0% and "to" as 100%', () => {
+      const animationRule = {
+        rule: 'slide-bottom',
+        content: 'from {  alpha: 0;   }  to {    alpha: 1;   y: 590;  }',
+      };
+      const animation = parseAnimationRule(animationRule);
+      expect(animation.steps['0']).toEqual({ alpha: '0' });
+      expect(animation.steps['100']).toEqual({ alpha: '1', y: '590' });
+    });
+  });
+
+  describe('parseCSSInnerHTML', () => {
+    test('should convert the css text to an object with all the rules', () => {
+      const rules = parseCSSInnerHTML(cssInnerHTML, 'rules');
+      Object.keys(rules).forEach((rule) => {
+        expect(cssObject[rule]).toEqual(rules[rule]);
+      });
+    });
+
+    test('should convert a text with the animation steps to an object with the steps as its properties ', () => {
+      const rules = parseCSSInnerHTML(`
+          from {
+            alpha: 0;
+          }
+          to {
+            alpha: 1;
+            y: 590;
+          }
+      `, 'animation');
+      expect(rules.from).toEqual({ alpha: '0' });
+      expect(rules.to).toEqual({ alpha: '1', y: '590' });
+    });
+
+    test('should find the rule withing the css text and return an object with all its properties ', () => {
+      const rules = parseCSSInnerHTML(cssInnerHTML, 'x100_y100');
+      expect(Object.keys(rules).length).toEqual(1);
+      expect(rules['.x100_y100']).toEqual({ x: '100', y: '100' });
+    });
+  });
+
+  describe('getAtRules', () => {
+    test('should find within the css text all the rules with @keyframes and remove white spaces ', () => {
+      getAtRules(cssInnerHTML, 'keyframes');
+      allAnimations.forEach((rule, index) => {
+        expect(allAnimations[index].content.replace(/\s/g, '')).toEqual(
+          rule.content.replace(/\s/g, ''),
+        );
+      });
+    });
+
+    test('should find within the css text all the rules with @media and remove white spaces ', () => {
+      const rules = getAtRules(cssInnerHTML, 'media');
+      expect(Object.keys(rules).length).toEqual(2);
+      expect(rules[0].content.replace(/\s/g, '')).toEqual(
+        'pixi.from-top-to-bottom{animation-name:slide-bottom;animation-duration:3000;}',
+      );
+    });
+  });
+
+  describe('castStringCSSValue', () => {
+    test('should cast css values that are wrong to "false" ', () => {
+      const value = castStringCSSValue(undefined);
+      expect(value).toEqual(false);
+    });
+    test('should cast css values that are wrong to "false"', () => {
+      const value = castStringCSSValue(null);
+      expect(value).toEqual(false);
+    });
+    test('should cast css string values that are numbers to a number ', () => {
+      const value = castStringCSSValue('1 !important');
+      expect(value).toEqual(1);
+    });
+    test('should leave css string values that are string', () => {
+      const value = castStringCSSValue('test !important');
+      expect(value).toEqual('test');
+    });
+    test('should cast css string values that are booleans to a boolean type', () => {
+      const value = castStringCSSValue('true !important');
+      expect(value).toEqual(true);
+    });
+    test('should cast css string values that are arrays to an array ', () => {
+      const value = castStringCSSValue('[1, 2, 3] !important');
+      expect(value).toEqual([1, 2, 3]);
+    });
+  });
+  // TODO seems the order does not matter but it should
+  describe('cssRuleMatch', () => {
+    test('should find the rule selector withing a text', () => {
+      const value = cssRuleMatch('.clickable', 'clickable');
+      expect(value).toEqual(true);
+    });
+    test('should find the rule selectors withing a text ', () => {
+      const value = cssRuleMatch('.clickable.test', 'clickable test');
+      expect(value).toEqual(true);
+    });
+    test('should find the rule selector withing a text regardless of the order', () => {
+      const value = cssRuleMatch(
+        '.selector.clickable.test',
+        'clickable selector test',
+      );
+      expect(value).toEqual(true);
+    });
+    test('should not match when there are not exactly all selectors', () => {
+      const value = cssRuleMatch(
+        '.selector.clickable',
+        'clickable selector test',
+      );
+      expect(value).toEqual(false);
+    });
+  });
+});

--- a/test/cssManager.spec.js
+++ b/test/cssManager.spec.js
@@ -1,0 +1,343 @@
+import {
+  createElement, TYPES,
+} from '../src/utils/element'
+import cssSource from '../src/cssManager/cssSource'
+import cssManager from '../src/cssManager/cssManager'
+import * as tweensUtils from '../src/cssManager/tweens';
+import { addTestStyleSheet, removeTestStyleSheet } from './__utils__/mock'
+
+jest.mock('../src/cssManager/cssSource', () => {
+  const animations = {
+    'animation-1': {
+      0: {
+
+      },
+      100: {
+
+      },
+    },
+  }
+  const allCSSRules = {
+    '.selector-1': {
+      y: '650',
+    },
+    '.selector-2': {
+      scaleX: '2',
+      scaleY: '2',
+    },
+    '.button': {
+      interactive: 'true',
+    },
+    '.text': {
+      fontSize: '10',
+      fontFamily: 'Arial',
+      fontStyle: 'Italic',
+      fontWeight: '300',
+    },
+    '.x-200': {
+      x: '200',
+    },
+
+    '.y-300': {
+      y: '300',
+    },
+    '.animation': {
+      alpha: '0.5',
+      animationName: 'animation-1',
+    },
+    '.transition': {
+      alpha: '0.5',
+      transitionProperty: 'x,y',
+    },
+    '.animation-not-present': {
+      alpha: '0.5',
+      animationName: 'animation-2',
+    },
+  }
+
+  const splitAndTrim = (string, separator) => (string
+    ? string.split(separator).map((item) => item.trim())
+    : [])
+
+
+  const containsAll = (selectorText, ors) => (selectorText ? ors.every((x) => selectorText.indexOf(x) >= 0) : false)
+  const cssRuleMatch = (haystack, niddle) => {
+    const haystackArr = splitAndTrim(haystack.substr(1, haystack.length), '.')
+    const niddleArr = splitAndTrim(niddle, ' ')
+    if (haystackArr.length === 1) {
+      return niddleArr.indexOf(haystackArr[0]) > -1
+    }
+    if (haystackArr.length === niddleArr.length) {
+      return containsAll(haystackArr, niddleArr)
+    }
+    return false
+  }
+  return {
+    addStyleSheet: jest.fn(),
+    addMediaQueryListener: jest.fn(),
+    removeMediaQueryListener: jest.fn(),
+    getCSSAnimationByName: (name) => animations[name],
+    getCSSRuleByName: (name) => {
+      let obj = {}
+      Object.keys(allCSSRules)
+        .filter((cssRule) => cssRuleMatch(cssRule.replace(/\s/g, ''), name))
+        .forEach((cssRule) => {
+          obj = { ...obj, ...allCSSRules[cssRule] }
+        })
+      return obj
+    },
+  }
+});
+
+jest.mock('../src/cssManager/tweens', () => ({
+  convertTransitionToTween: jest.fn(),
+  convertAnimationToTween: jest.fn(),
+}));
+
+describe('cssManager init', () => {
+  let element
+  let stage
+  let applyProps
+  beforeEach(() => {
+    jest.resetAllMocks()
+    addTestStyleSheet('')
+    stage = createElement(TYPES.Container)
+    element = createElement(TYPES.Container)
+    stage.addChild(element)
+    applyProps = jest.fn()
+    cssManager(element, 'Container', applyProps)
+  });
+  afterEach(() => {
+    stage.destroy()
+    removeTestStyleSheet()
+  });
+
+  test('that it should call addMediaQueryListener when starting the cssManager', () => {
+    const spy1 = jest.spyOn(cssSource, 'addMediaQueryListener')
+    expect(spy1).toHaveBeenCalled()
+  })
+
+  test('that it should call removeMediaQueryListener when removing the element', () => {
+    const spy1 = jest.spyOn(cssSource, 'removeMediaQueryListener')
+    stage.removeChild(element)
+    expect(spy1).toHaveBeenCalled()
+  })
+})
+
+describe('cssManager setCSSProps', () => {
+  let element = {
+    scale: { x: 1, y: 1 },
+    position: { x: 0, y: 0 },
+    on: jest.fn(),
+    setProps: jest.fn(),
+  }
+  let applyProps
+  let cssMan
+  beforeEach(() => {
+    jest.resetAllMocks()
+    addTestStyleSheet('')
+    element = { ...element }
+    applyProps = jest.fn()
+    cssMan = cssManager(element, 'Container', applyProps)
+  });
+  afterEach(() => {
+    removeTestStyleSheet()
+  });
+
+  test('add single stylesheet generate by styled components and take last selector of the class when passing styled:true ', () => {
+    cssMan.setProps({ styled: true })
+    cssMan.setCSSProps('selector-1 selector-2')
+    const spy1 = jest.spyOn(cssSource, 'addStyleSheet')
+    expect(spy1).toHaveBeenCalledWith('', 'selector-2')
+  })
+  test('when it is an update, it is not needed to add the stylesheet again', () => {
+    cssMan.setProps({ styled: true })
+    cssMan.setCSSProps('selector-1 selector-2', true)
+    const spy1 = jest.spyOn(cssSource, 'addStyleSheet')
+    expect(spy1).not.toHaveBeenCalled()
+  })
+  test('when is not styled component, addStyleSheet is not to be called', () => {
+    cssMan.setProps({ styled: false })
+    cssMan.setCSSProps('selector-1 selector-2')
+    const spy1 = jest.spyOn(cssSource, 'addStyleSheet')
+    expect(spy1).not.toHaveBeenCalled()
+  })
+
+  test('that it should return an object with the props set by the css', () => {
+    cssMan.setProps({ styled: false })
+    const cssProps = cssMan.setCSSProps('selector-1 selector-2')
+    expect(cssProps).toEqual({
+      y: 650, scaleX: 2, scaleY: 2, style: {},
+    })
+  })
+
+  test('that it should return an object with the props set by the css and any element specific prop passed as additional', () => {
+    cssMan.setProps({ styled: false })
+    const cssProps = cssMan.setCSSProps('selector-1 selector-2', true, {
+      width: 300,
+    })
+    expect(cssProps).toEqual({
+      y: 650, scaleX: 2, scaleY: 2, style: {}, width: 300,
+    })
+  })
+
+  test('that it should give the element a getCSSBasedProps which return an object', () => {
+    cssMan.setProps({ styled: false })
+    cssMan.setCSSProps('selector-1', true, {
+      width: 300,
+    })
+    expect(element.getCSSBasedProps()).toEqual({
+      y: 650, style: {},
+    })
+  })
+})
+
+
+describe('cssManager setCSSProps with classes that do not exist', () => {
+  let element = {
+    scale: { x: 1, y: 1 },
+    position: { x: 0, y: 0 },
+    interactive: true,
+    on: jest.fn(),
+    setProps: jest.fn(),
+  }
+  let applyProps
+  let cssMan
+  beforeEach(() => {
+    jest.resetAllMocks()
+    addTestStyleSheet('')
+    element = { ...element }
+    applyProps = jest.fn()
+    cssMan = cssManager(element, 'Container', applyProps)
+  });
+  afterEach(() => {
+    removeTestStyleSheet()
+  });
+
+  test('that it should return the initial element properties if class does not exist', () => {
+    cssMan.setProps({ styled: false })
+    const cssProps = cssMan.setCSSProps('unexistingClass')
+    expect(cssProps).toEqual({
+      style: {},
+    })
+  })
+
+  test('that it should return the initial element properties if class does not exist', () => {
+    cssMan.setProps({ styled: false })
+    const cssProps = cssMan.setCSSProps(null)
+    expect(cssProps).toEqual({
+      style: {},
+    })
+  })
+})
+
+describe('cssManager setCSSProps with Text type elements', () => {
+  let element = {
+    scale: { x: 1, y: 1 },
+    position: { x: 0, y: 0 },
+    on: jest.fn(),
+    setProps: jest.fn(),
+  }
+  let applyProps
+  let cssMan
+  beforeEach(() => {
+    jest.resetAllMocks()
+    addTestStyleSheet('')
+    element = { ...element }
+    applyProps = jest.fn()
+    cssMan = cssManager(element, 'Text', applyProps)
+  });
+  afterEach(() => {
+    removeTestStyleSheet()
+  });
+  test('Font properties should be part of the style object ', () => {
+    cssMan.setProps({ styled: false })
+    const cssProps = cssMan.setCSSProps('text')
+    expect(cssProps).toEqual({
+      style: {
+        fontSize: 10, fontFamily: 'Arial', fontStyle: 'Italic', fontWeight: 300,
+      },
+    })
+  })
+})
+
+describe('cssManager setCSSProps adding the later removing classes', () => {
+  let element = {
+    scale: { x: 1, y: 1 },
+    position: { x: 10, y: 10 },
+    on: jest.fn(),
+    setProps: jest.fn(),
+  }
+  let applyProps
+  let cssMan
+  beforeEach(() => {
+    jest.resetAllMocks()
+    element = { ...element }
+    applyProps = jest.fn()
+    cssMan = cssManager(element, 'Container', applyProps)
+  });
+
+  test('that it should always return the initial properties when a property is initially set by a css and then later is not', () => {
+    let cssProps
+    cssMan.setProps({ styled: false })
+    cssProps = cssMan.setCSSProps('x-200')
+    expect(cssProps).toEqual({
+      x: 200, style: {},
+    })
+    cssProps = cssMan.setCSSProps('x-200 y-300', true)
+    expect(cssProps).toEqual({
+      x: 200, y: 300, style: {},
+    })
+    cssProps = cssMan.setCSSProps('x-200', true)
+    expect(cssProps).toEqual({
+      x: 200, y: 10, style: {},
+    })
+    cssProps = cssMan.setCSSProps('', true)
+    expect(cssProps).toEqual({
+      x: 10, y: 10, style: {},
+    })
+  })
+})
+
+describe('cssManager setCSSProps calling tween methods for transitions or animations', () => {
+  let element = {
+    scale: { x: 1, y: 1 },
+    position: { x: 10, y: 10 },
+    on: jest.fn(),
+    setProps: jest.fn(),
+  }
+  let applyProps
+  let cssMan
+  beforeEach(() => {
+    jest.resetAllMocks()
+    element = { ...element }
+    applyProps = jest.fn()
+    cssMan = cssManager(element, 'Container', applyProps)
+  });
+
+  test('that it should call the convertAnimationToTween when a css class has animation-name prop and the animation exists', () => {
+    cssMan.setProps({ styled: false })
+    const spy1 = jest.spyOn(tweensUtils, 'convertAnimationToTween')
+    const cssProps = cssMan.setCSSProps('animation')
+    expect(spy1).toHaveBeenCalledWith(element, { 0: {}, 100: {} }, { animationName: 'animation-1' })
+    expect(cssProps).toEqual({ alpha: '0.5', style: {} })
+  })
+
+  test('that it should not call the convertAnimationToTween when a css class has animation-name prop but the animation does not exists', () => {
+    cssMan.setProps({ styled: false })
+    const spy1 = jest.spyOn(tweensUtils, 'convertAnimationToTween')
+    cssMan.setCSSProps('animation-not-present')
+    expect(spy1).not.toHaveBeenCalled()
+  })
+
+  test('that it should call the convertTransitionToTween when a css class has a transition-property prop, but only after the 1st time', () => {
+    let cssProps
+    cssMan.setProps({ styled: false })
+    const spy1 = jest.spyOn(tweensUtils, 'convertTransitionToTween')
+    cssProps = cssMan.setCSSProps('transition y-300')
+    expect(spy1).not.toHaveBeenCalled()
+    expect(cssProps).toEqual({ alpha: '0.5', y: 300, style: {} })
+    cssProps = cssMan.setCSSProps('transition y-300', true)
+    expect(spy1).toHaveBeenCalledWith(element, { y: 300 }, { transitionProperty: 'x,y' })
+  })
+})

--- a/test/cssSource.spec.js
+++ b/test/cssSource.spec.js
@@ -1,0 +1,113 @@
+window.TimelineMax = props => {
+  return {
+    getProps: jest.fn().mockReturnValue(props),
+    to: jest.fn(),
+    reverse: jest.fn(),
+    kill: jest.fn()
+  };
+};
+
+describe('cssSource', () => {
+  let cssSource
+  let cssInnerHTML
+  beforeEach(() => {
+    jest.resetModules()
+    
+
+    cssInnerHTML = require('./__utils__/mock').cssInnerHTML
+    cssSource = require('../src/cssManager/cssSource').default;
+    cssSource.addStyleSheet(cssInnerHTML)
+  });
+
+  describe('hasMediaQuery', () => {
+    test('that it should return true when a css rule is also in mediaqueries', () => {
+      expect(cssSource.hasMediaQuery('.from-top-to-bottom')).toEqual(true)
+    });
+  });
+
+  describe('getCSSAnimationByName', () => {
+    test('that it should return a found css animations with all its props', () => {
+      expect(cssSource.getCSSAnimationByName('slide-bottom')).toEqual({
+        steps: { 0: { alpha: '0' }, 100: { alpha: '1', y: '590' } },
+      })
+    });
+  });
+
+  describe('getCSSRuleByName', () => {
+    test('that it should return a found css rule with all its props', () => {
+      expect(cssSource.getCSSRuleByName('from-top-to-bottom')).toEqual({
+        alpha: '0',
+        animationDelay: '1000',
+        animationDuration: '1000',
+        animationName: 'slide-bottom',
+      })
+    });
+
+
+    test('that it should return a found css rule with all its props included the ones in matching mediaqueries', () => {
+      expect(cssSource.getCSSRuleByName('from-top-to-bottom-with-mediaquery')).toEqual({
+        alpha: '0',
+        animationDelay: '1000',
+        animationDuration: '3000',
+        animationName: 'slide-bottom',
+      })
+    });
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks()
+  });
+})
+
+describe('cssSource', () => {
+  let cssSource
+  beforeEach(() => {
+    jest.resetModules()
+   
+
+    cssSource = require('../src/cssManager/cssSource').default;
+    cssSource.addStyleSheet('')
+  });
+
+  describe('addMediaQueryListener with not matching mediaqueries', () => {
+    test('that it should add correctly a matching mediaquery event listener and not dispatched if a rule is not matching', () => {
+      let called = false
+      cssSource.addMediaQueryListener(() => {
+        called = true
+      })
+      expect(called).toEqual(false)
+    });
+  });
+
+  describe('addMediaQueryListener', () => {
+    test('that it should add correctly a matching mediaquery event listener and dispatched if a rule is matching', () => {
+      const { cssInnerHTML } = require('./__utils__/mock')
+      let called = false
+      cssSource.addMediaQueryListener(() => {
+        called = true
+      })
+      cssSource.addStyleSheet(cssInnerHTML)
+
+      expect(called).toEqual(true)
+    });
+  });
+
+  describe('removeMediaQueryListener', () => {
+    test('that it should no longer dispatch a matching mediaquery event if the listener is removed', () => {
+      const { cssInnerHTML } = require('./__utils__/mock')
+      let called = false
+      const callback = () => {
+        called = true
+      }
+      cssSource.addMediaQueryListener(callback)
+      cssSource.removeMediaQueryListener(callback)
+      cssSource.addStyleSheet(cssInnerHTML)
+      expect(called).toEqual(false)
+    });
+  });
+
+
+  afterEach(() => {
+    jest.resetAllMocks()
+  });
+})

--- a/test/element.spec.js
+++ b/test/element.spec.js
@@ -1,9 +1,22 @@
 import * as PIXI from 'pixi.js'
 import { createElement, TYPES, TYPES_INJECTED, PixiComponent } from '../src/utils/element'
-
+import cssManager from '../src/cssManager/cssManager'
+import * as propsUtils from '../src/utils/props';
 import { emptyTexture } from './__fixtures__/textures'
 import { desyrel } from './__fixtures__/bitmapfonts'
 import parseBitmapFont from './__utils__/parseBitmapFont'
+
+jest.mock('../src/cssManager/cssManager');
+
+
+cssManager.mockImplementation(() => {
+  return {
+    setCSSProps: jest.fn().mockReturnValue({}),
+    getCSSProps: jest.fn(),
+    setProps: jest.fn(),
+  }
+});
+
 
 parseBitmapFont(desyrel)
 
@@ -228,6 +241,31 @@ describe('element.applyProps', () => {
     expect(draw).toHaveBeenCalledTimes(1)
   })
 
+
+})
+
+describe ('Use of cssManager', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  })
+  test('cssManager should be defined for the element', () => {
+    const element = createElement(TYPES.Container, { className: 'btn'})
+    expect(element).toHaveProperty('cssManager')
+    expect(cssManager).toHaveBeenCalled()
+  })
+  test('setProps and setCSSProps should be called', () => {
+    const element = createElement(TYPES.Container, { className: 'btn', x: 0, y: 0 })
+    const spy1 = jest.spyOn(element.cssManager, 'setProps')
+    const spy2 = jest.spyOn(element.cssManager, 'setCSSProps')
+    expect(spy1).toHaveBeenCalledWith({x: 0, y: 0});
+    expect(spy2).toHaveBeenCalledWith('btn', null, {'x': 0, 'y': 0});  
+  })
+
+  test('applyProps should be called', () => {
+    propsUtils.applyDefaultProps = jest.fn();
+    const element = createElement(TYPES.Container, { className: 'btn', x: 0, y: 0 })
+    expect(propsUtils.applyDefaultProps).toHaveBeenCalled();  
+  })
 
 })
 

--- a/test/tweens.spec.js
+++ b/test/tweens.spec.js
@@ -1,0 +1,274 @@
+import { convertAnimationToTween, convertTransitionToTween } from '../src/cssManager/tweens';
+
+window.TimelineMax = props => {
+  return {
+    getProps: jest.fn().mockReturnValue(props),
+    to: jest.fn(),
+    reverse: jest.fn(),
+    kill: jest.fn()
+  };
+};
+
+const baseAnimationProps = {
+  steps: {
+    0: {
+      x: 0,
+    },
+    50: {
+      x: 50,
+    },
+    100: {
+      x: 100,
+    },
+  },
+};
+
+const baseAnimationParams = {
+  animationDuration: 1000,
+  animationDelay: 1000,
+  animationIterationCount: 1,
+  animationDirection: 'normal',
+  animationTimingFunction: 'linear',
+  animationPlayState: 'running',
+};
+
+
+const baseTransitionProps = {
+  x: 0,
+  y: 0,
+}
+
+const baseTransitionParams = {
+   transitionProperty: 'x, y',
+   transitionDuration: 1000,
+   transitionDelay: 1000,
+   transitionTimingFunction: 'linear',
+}
+
+describe('Tweens with css animations', () => {
+  // let animationProps
+  // let animationParams
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+
+
+  });
+  afterEach(() => {});
+
+  test('that it should convert the cssProps to the proper tween parameters', () => {
+    const element = {};
+    const animationProps = {
+      ...baseAnimationProps,
+    };
+    const animationParams = {
+      ...baseAnimationParams,
+    };
+    const animationsTimeline = convertAnimationToTween(element, animationProps, animationParams);
+
+    const props = animationsTimeline.getProps();
+    expect(props.paused).toEqual(false);
+    expect(props.yoyo).toEqual(false);
+    expect(props.delay).toEqual(1);
+    expect(props.repeat).toEqual(0);
+  });
+  test('that it should convert animationPlayState:paused to paused: true, animationDirection: alternate to yoyo: true and  animationDirection: infinite to repeat: -1', () => {
+    const element = {};
+    const animationProps = {
+      ...baseAnimationProps,
+    };
+    const animationParams = {
+      ...baseAnimationParams,
+      ...{
+        animationPlayState: 'paused',
+        animationDirection: 'alternate',
+        animationIterationCount: 'infinite',
+      },
+    };
+    const animationsTimeline = convertAnimationToTween(element, animationProps, animationParams);
+
+    const props = animationsTimeline.getProps();
+    expect(props.yoyo).toEqual(true);
+    expect(props.paused).toEqual(true);
+    expect(props.repeat).toEqual(-1);
+  });
+
+  test('that it should make animationDirection: reverse to call the tween method reverse', () => {
+    const element = {};
+    const animationProps = {
+      ...baseAnimationProps,
+    };
+    const animationParams = {
+      ...baseAnimationParams,
+      ...{
+        animationPlayState: 'running',
+        animationDirection: 'reverse',
+      },
+    };
+    const animationsTimeline = convertAnimationToTween(element, animationProps, animationParams);
+
+    expect(animationsTimeline.reverse).toHaveBeenCalled();
+  });
+
+  test('that it should split all animation steps in call to the "to" method of the timeline object', () => {
+    const element = {};
+    const animationProps = {
+      ...baseAnimationProps,
+    };
+    const animationParams = {
+      ...baseAnimationParams,
+    };
+    const animationsTimeline = convertAnimationToTween(element, animationProps, animationParams);
+    // const spy1 = jest.spyOn(animationsTimeline, 'to')
+    expect(animationsTimeline.to).toHaveBeenCalledTimes(3);
+    expect(animationsTimeline.to).toHaveBeenNthCalledWith(1, {}, 0, { ease: 'linear', pixi: { x: 0 } });
+    expect(animationsTimeline.to).toHaveBeenNthCalledWith(2, {}, 0.5, { ease: 'linear', pixi: { x: 50 } });
+    expect(animationsTimeline.to).toHaveBeenNthCalledWith(3, {}, 0.5, { ease: 'linear', pixi: { x: 100 } });
+  });
+
+  test('that it should split all animation steps in call to the "to" method of the timeline object redistributing correctly the animation time based on the percentages', () => {
+    const element = {};
+    const animationProps = {
+      ...baseAnimationProps,
+    };
+    const animationParams = {
+      ...baseAnimationParams,
+      ...{
+        animationDuration: 2000,
+      },
+    };
+    const animationsTimeline = convertAnimationToTween(element, animationProps, animationParams);
+    // const spy1 = jest.spyOn(animationsTimeline, 'to')
+    expect(animationsTimeline.to).toHaveBeenCalledTimes(3);
+    expect(animationsTimeline.to).toHaveBeenNthCalledWith(1, {}, 0, { ease: 'linear', pixi: { x: 0 } });
+    expect(animationsTimeline.to).toHaveBeenNthCalledWith(2, {}, 1, { ease: 'linear', pixi: { x: 50 } });
+    expect(animationsTimeline.to).toHaveBeenNthCalledWith(3, {}, 1, { ease: 'linear', pixi: { x: 100 } });
+  });
+
+  test('that it should split all animation steps in call to the "to" method of the timeline object redistributing correctly the animation time based on the percentages', () => {
+    const element = {};
+    const animationProps = {
+      ...baseAnimationProps,
+      ...{
+        steps: {
+          0: {
+            x: 0,
+          },
+          25: {
+            x: 25,
+          },
+          50: {
+            x: 50,
+          },
+          100: {
+            x: 100,
+          },
+        },
+      },
+    };
+    const animationParams = {
+      ...baseAnimationParams,
+      ...{
+        animationDuration: 1500,
+      },
+    };
+    const animationsTimeline = convertAnimationToTween(element, animationProps, animationParams);
+    // const spy1 = jest.spyOn(animationsTimeline, 'to')
+    expect(animationsTimeline.to).toHaveBeenCalledTimes(4);
+    expect(animationsTimeline.to).toHaveBeenNthCalledWith(1, {}, 0, { ease: 'linear', pixi: { x: 0 } });
+    expect(animationsTimeline.to).toHaveBeenNthCalledWith(2, {}, 0.375, { ease: 'linear', pixi: { x: 25 } });
+    expect(animationsTimeline.to).toHaveBeenNthCalledWith(3, {}, 0.375, { ease: 'linear', pixi: { x: 50 } });
+    expect(animationsTimeline.to).toHaveBeenNthCalledWith(4, {}, 0.75, { ease: 'linear', pixi: { x: 100 } });
+  });
+
+
+  test('that it should call the animation kill and the animationEnd call back (if any has passed) once the tween is done ', () => {
+    const element = {};
+    const animationProps = {
+      ...baseAnimationProps,
+    };
+    const animationParams = {
+      ...baseAnimationParams,
+    };
+    element.animationEnd = jest.fn()
+    const animationsTimeline = convertAnimationToTween(element, animationProps, animationParams);
+    const props = animationsTimeline.getProps();
+    const { onComplete } = props
+    onComplete()
+    expect(animationsTimeline.kill).toHaveBeenCalled();
+    expect(element.animationEnd).toHaveBeenCalled();
+  });
+
+  test('that it should call the animation kill and the animationEnd call back (if any has passed) once the tween is done reversely', () => {
+    const element = {};
+    const animationProps = {
+      ...baseAnimationProps,
+    };
+    const animationParams = {
+      ...baseAnimationParams,
+      ...{
+        animationDirection: 'reverse',
+      },
+    };
+    element.animationEnd = jest.fn()
+    const animationsTimeline = convertAnimationToTween(element, animationProps, animationParams);
+    const props = animationsTimeline.getProps();
+    const { onReverseComplete } = props
+    onReverseComplete()
+    expect(animationsTimeline.kill).toHaveBeenCalled();
+    expect(element.animationEnd).toHaveBeenCalled();
+  });
+});
+
+describe('Tweens with css transitions', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+ 
+
+  });
+  afterEach(() => {});
+
+  test('that it should convert the cssProps to the proper tween parameters', () => {
+    const element = {};
+    const transitionProps = {
+      ...baseTransitionProps,
+    };
+    const transitionParams = {
+      ...baseTransitionParams,
+    };
+    const transitionTimeline = convertTransitionToTween(element, transitionProps, transitionParams);
+    const props = transitionTimeline.getProps();
+    expect(props.delay).toEqual(1);
+    expect(props.ease).toEqual('linear');
+  });
+
+  test('that it should split all animation steps in call to the "to" method of the timeline object', () => {
+    const element = {};
+    const transitionProps = {
+      ...baseTransitionProps,
+    };
+    const transitionParams = {
+      ...baseTransitionParams,
+    };
+    const transitionTimeline = convertTransitionToTween(element, transitionProps, transitionParams);
+    expect(transitionTimeline.to).toHaveBeenCalledTimes(1);
+    expect(transitionTimeline.to).toHaveBeenCalledWith({}, 1, { ease: 'linear', pixi: { x: 0, y: 0 } });
+  });
+
+  test('that it should call the animation kill and the transitionEnd call back (if any has passed) once the tween is done', () => {
+    const element = {};
+    const transitionProps = {
+      ...baseTransitionProps,
+    };
+    const transitionParams = {
+      ...baseTransitionParams,
+    };
+    element.transitionEnd = jest.fn()
+    const transitionTimeline = convertTransitionToTween(element, transitionProps, transitionParams);
+    const props = transitionTimeline.getProps();
+    const { onComplete } = props
+    onComplete()
+    expect(transitionTimeline.kill).toHaveBeenCalled();
+    expect(element.transitionEnd).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
<!--
Thank you very much for your pull request!
-->
This PR adds allows to use the className attribute in PIXI components and refers to classes defined in css files as if you would do while working with HTML DOM applications. This introduces also CSS media queries, CSS animations and transitions and the support for styled-component library.

**Related issue (if exists):** #155 