### PR TITLE
FIx Parcel bundler support

### DIFF
--- a/module.js
+++ b/module.js
@@ -1,1 +1,5 @@
-module.exports = require(`./dist/react-pixi.module${process.env.NODE_ENV === 'development' ? '-dev' : ''}`)
+if(process.env.NODE_ENV === 'development' ) {
+    module.exports = require("./dist/react-pixi.module-dev");
+} else {
+    module.exports = require("./dist/react-pixi.module");
+}


### PR DESCRIPTION
Parcel doesn't like the syntax for the require statement (at least when using TypeScript), and is unable to resolve the module. Changing to an if/else statement fixes the problem. This should only be needed in the module.js file, as Parcel will always use this.

