### PR TITLE
Fix `Stage` default height in docs to be correct value

### DIFF
--- a/src/stage/Stage.mdx
+++ b/src/stage/Stage.mdx
@@ -17,7 +17,7 @@ The Stage component renders a `PIXI.Application` onto a canvas element and makes
 | Prop  | Description | Default value |
 | ------------- | ------------- | ------------- |
 | `width`  | the width of the renderers view  | `800` |
-| `height`  | the height of the renderers view  | `800` |
+| `height`  | the height of the renderers view  | `600` |
 | `onMount`  | callback function for the created app instance  | |
 | `onUnMount`  | callback function when the Stage gets unmounted  | |
 | `raf`  | use the internal PIXI ticker (requestAnimationFrame)  | `true` |


### PR DESCRIPTION
<!--
Thank you very much for your pull request!
-->

First of all, thank you very much for this awesome library!

**Description:**

This is a tiny change that fixes the `Stage` doc page to have the correct default `height` value in the props table (from `800` to `600`).

Please let me know if you need anything else.