### PR TITLE
Update AnimatedSprite play state and add types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -152,6 +152,12 @@ declare namespace _ReactPixi {
     indices?: ConstructorParameters<typeof PIXI.SimpleMesh>[3];
   };
 
+  type IAnimatedSprite = Container<PIXI.AnimatedSprite> & {
+    initialFrame?: number;
+    images?: string[];
+    isPlaying?: boolean;
+  };
+
   type IStage = React.CanvasHTMLAttributes<HTMLCanvasElement> & {
     /**
      * Width of the Stage and canvas
@@ -253,6 +259,7 @@ export class ParticleContainer extends React.Component<_ReactPixi.IParticleConta
 export class TilingSprite extends React.Component<_ReactPixi.ITilingSprite> {}
 export class SimpleRope extends React.Component<_ReactPixi.ISimpleRope> {}
 export class SimpleMesh extends React.Component<_ReactPixi.ISimpleMesh> {}
+export class AnimatedSprite extends React.Component<_ReactPixi.IAnimatedSprite> {}
 
 // renderer
 export const render: (

--- a/src/components/AnimatedSprite.js
+++ b/src/components/AnimatedSprite.js
@@ -3,22 +3,21 @@ import { getTextureFromProps, applyDefaultProps } from '../utils/props'
 
 const AnimatedSprite = (root, props) => {
   const { textures, images, autoUpdate, isPlaying = true, initialFrame } = props
-  const makeTexture = textures => {
-    return textures.map(texture => {
-      return getTextureFromProps('AnimatedSprite', {
-        texture,
-      })
-    })
-  }
+  const makeTexture = textures => textures.map(texture => getTextureFromProps('AnimatedSprite', { texture }))
+
   const animatedSprite = images ? PixiAnimatedSprite.fromImages(images) : new PixiAnimatedSprite(makeTexture(textures))
   animatedSprite[isPlaying ? 'gotoAndPlay' : 'gotoAndStop'](initialFrame || 0)
   animatedSprite.applyProps = (instance, oldProps, newProps) => {
-    const { textures, ...props } = newProps
-    const { isPlaying, initialFrame } = props
+    const { textures, isPlaying, initialFrame, ...props } = newProps
+
     applyDefaultProps(instance, oldProps, props)
+
     if (textures && oldProps['textures'] !== textures) {
       instance.textures = makeTexture(textures)
-      animatedSprite[isPlaying ? 'gotoAndPlay' : 'gotoAndStop'](initialFrame || 0)
+    }
+
+    if (isPlaying !== oldProps.isPlaying) {
+      animatedSprite[isPlaying ? 'gotoAndPlay' : 'gotoAndStop'](animatedSprite.currentFrame || 0)
     }
   }
 


### PR DESCRIPTION
Add types for `AnimatedSprite` and update play state respectively.

Fixes #194 and #195 