### PR TITLE
Apply PointLike type to skew

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -81,7 +81,7 @@ declare namespace _ReactPixi {
     [P in PIXI.interaction.InteractionEventTypes]?: (event: PIXI.interaction.InteractionEvent) => void;
   };
 
-  type P = 'position' | 'scale' | 'pivot' | 'anchor';
+  type P = 'position' | 'scale' | 'pivot' | 'anchor' | 'skew';
 
   type Container<T extends PIXI.DisplayObject> = Partial<Omit<T, 'children' | P>> &
     Partial<WithPointLike<P>> &


### PR DESCRIPTION
**Description:**

I could't use a type like `[number, number]` for `skew` of `PIXI.Sprite`.
So I fix it.

**Related issue (if exists):**
