### PR TITLE
Fix broken withFilters type inference

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -425,7 +425,7 @@ export const applyDefaultProps: <P extends object>(
  * }
  */
 export const withFilters: <
-  Component extends React.ComponentType<_ReactPixi.IContainer>,
+  Component extends React.ComponentType<any>,
   Filters extends { [filterKey: string]: any }
 >(
   WrapperComponent: Component,

--- a/index.d.ts
+++ b/index.d.ts
@@ -425,7 +425,9 @@ export const applyDefaultProps: <P extends object>(
  * }
  */
 export const withFilters: <
-  Component extends React.ComponentType<any>,
+  Component extends React.ComponentType<
+    _ReactPixi.Container<PIXI.DisplayObject, any>
+  >,
   Filters extends { [filterKey: string]: any }
 >(
   WrapperComponent: Component,


### PR DESCRIPTION
<!--
Thank you very much for your pull request!
-->

**Description:**

I've got this type error from recent update.

```
Argument of type 'FC<Container<Graphics, { draw?(graphics: Graphics): void; preventRedraw?: boolean | undefined; }>>' is not assignable to parameter of type 'ComponentType<Container<Container, {}>>'.
  Type 'FunctionComponent<Container<Graphics, { draw?(graphics: Graphics): void; preventRedraw?: boolean | undefined; }>>' is not assignable to type 'FunctionComponent<Container<Container, {}>>'.
    Types of parameters 'props' and 'props' are incompatible.
      Type 'PropsWithChildren<Container<Container, {}>>' is not assignable to type 'PropsWithChildren<Container<Graphics, { draw?(graphics: Graphics): void; preventRedraw?: boolean | undefined; }>>'.
        Type 'PropsWithChildren<Container<Container, {}>>' is not assignable to type 'Partial<Pick<Graphics, "y" | "x" | "alpha" | "name" | "accessible" | "accessibleTitle" | "accessibleHint" | "_accessibleActive" | "_accessibleDiv" | "accessibleType" | ... 88 more ... | "endHole"> & WithPointLike<...>>'.
          Types of property 'on' are incompatible.
            Type '{ (event: InteractionPixiEvents, fn: (displayObject: DisplayObject) => void, context?: any): Container; (event: string, fn: Function, context?: any): Container; } | undefined' is not assignable to type '{ (event: InteractionPixiEvents, fn: (displayObject: DisplayObject) => void, context?: any): Graphics; (event: string, fn: Function, context?: any): Graphics; } | undefined'.
              Type '{ (event: InteractionPixiEvents, fn: (displayObject: DisplayObject) => void, context?: any): Container; (event: string, fn: Function, context?: any): Container; }' is not assignable to type '{ (event: InteractionPixiEvents, fn: (displayObject: DisplayObject) => void, context?: any): Graphics; (event: string, fn: Function, context?: any): Graphics; }'.  TS2345

    27 | });
    28 | 
  > 29 | const Highlight = withFilters(Graphics, {
       |                               ^
    30 |   glow: GlowFilter,
    31 | });
```

Seems type constraint here does not match with supertype.

**Related issue (if exists):**
