### PR TITLE
Add object type support for _ReactPixi.PointLike

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -54,7 +54,8 @@ declare namespace _ReactPixi {
     | PIXI.ObservablePoint
     | [number, number]
     | [number]
-    | number;
+    | number
+    | { x: number, y: number };
   type ImageSource = string | HTMLImageElement;
   type VideoSource = string | HTMLVideoElement;
   type AnySource = number | ImageSource | VideoSource | HTMLCanvasElement | PIXI.Texture;


### PR DESCRIPTION
**Description:**
This pull request modifies `_ReactPixi.PointLike` type definition to accept `{x: number, y:number}`

I wanted to pass `{x: number, y:number}` to `<TilingSprite />` 's `tilePosition` prop and `tileScale` prop as [noted in the doc](https://reactpixi.org/components/tiling-sprite), but that gave me type error.   
```
Type '{ x: number; y: number; }' is not assignable to type 'number | ObservablePoint | Point | [number, number] | [number] | undefined'.
  Type '{ x: number; y: number; }' is not assignable to type 'undefined'.
```

As far as I read the source code(https://github.com/inlet/react-pixi/blob/master/src/components/TilingSprite.js#L15-L17
and https://github.com/inlet/react-pixi/blob/master/src/utils/pixi.js#L23-L26), `{x: number, y:number}` case seems like considered so I would like to add type support for that style.

**Related issue (if exists):**
