### PR TITLE
Update resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -142,10 +142,10 @@
   },
   "jest": {
     "collectCoverage": false,
-    "rootDir": "./test",
     "setupFiles": [
       "jest-webgl-canvas-mock",
-      "./bootstrap.js"
+      "<rootDir>/test/bootstrap.js",
+      "<rootDir>/test/__mocks__/matchMediaMock.js"
     ]
   }
 }

--- a/test/__mocks__/matchMediaMock.js
+++ b/test/__mocks__/matchMediaMock.js
@@ -1,0 +1,13 @@
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: jest.fn().mockImplementation(query => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: jest.fn(), // deprecated
+    removeListener: jest.fn(), // deprecated
+    addEventListener: jest.fn(),
+    removeEventListener: jest.fn(),
+    dispatchEvent: jest.fn(),
+  })),
+})

--- a/test/reconciler.test.js
+++ b/test/reconciler.test.js
@@ -304,7 +304,7 @@ describe('reconciler', () => {
       return <Text text={text} />
     }
 
-    test('renders suspense fallback', async () => {
+    test('renders suspense fallback', () => {
       jest.useFakeTimers()
 
       const loadingTextRef = React.createRef(null)
@@ -328,7 +328,7 @@ describe('reconciler', () => {
       expect(siblingTextRef.current.visible).toEqual(false)
     })
 
-    test('renders suspense content', async () => {
+    test('renders suspense content', () => {
       jest.useFakeTimers()
 
       const siblingTextRef = React.createRef(null)

--- a/wallaby.js
+++ b/wallaby.js
@@ -2,8 +2,21 @@
 
 module.exports = function (wallaby) {
   return {
-    files: ['src/**/*.js', 'package.json', 'test/__fixtures__/**/*', 'test/__utils__/**/*', 'test/bootstrap.js'],
-    tests: ['test/**/*.js', '!test/bootstrap.js', '!test/__fixtures__/**/*', '!test/__utils__/**/*'],
+    files: [
+      'src/**/*.js',
+      'package.json',
+      'test/__fixtures__/**/*',
+      'test/__utils__/**/*',
+      'test/bootstrap.js',
+      'test/__mocks__/**/*',
+    ],
+    tests: [
+      'test/**/*.js',
+      '!test/bootstrap.js',
+      '!test/__fixtures__/**/*',
+      '!test/__utils__/**/*',
+      '!test/__mocks__/**/*',
+    ],
 
     compilers: {
       '**/*.js?(x)': wallaby.compilers.babel(),
@@ -14,12 +27,5 @@ module.exports = function (wallaby) {
     },
 
     testFramework: 'jest',
-
-    setup: function () {
-      const jestConfig = require('./package.json').jest
-      jestConfig.setupFiles = ['jest-webgl-canvas-mock', './test/bootstrap.js']
-
-      wallaby.testFramework.configure(jestConfig)
-    },
   }
 }


### PR DESCRIPTION
# Implement resolution

Fixes #127

## Update renderer resolution

It now updates the PIXI renderer resolution if Stage prop `options.resolution` changes.

```jsx
// first render
<Stage options={{ resolution: 1 }}>

// second render
<Stage options={{ resolution: 2 }}>

// the internal renderer updates its resolution to 2
```

## Option `autoDensity`

It integrates the [PIXI.AbstractRenderer#autoDensity](https://pixijs.download/dev/docs/PIXI.AbstractRenderer.html#autoDensity) properly, including auto resolution.

```jsx
<Stage options={{ autoDensity: true }}>
```

### Auto resolution

When the browser is moved across displays with different screen resolutions, the renderer resolution is automatically updated (using an internal mediaQuery to detect resolution changes).

You can always hard set the resolution to bypass the auto resolution behaviour:

```jsx
<Stage options={{ resolution: 1 }}>
```

