### PR TITLE
Remove "preventRedraw" prop from index.d.ts

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -158,15 +158,6 @@ declare namespace _ReactPixi {
      * }}
      */
     draw?(graphics: PIXI.Graphics): void;
-
-    /**
-     * Set `preventRedraw` to true to force the component to be drawn only once
-     *
-     * @example
-     *
-     * preventRedraw={true}
-     */
-    preventRedraw?: boolean;
   }>;
 
   type IBitmapText = Container<


### PR DESCRIPTION
<!--
Thank you very much for your pull request!
-->

**Description:**

Removes the `preventRedraw` property because it is still present in index.d.ts.

https://github.com/inlet/react-pixi/blob/master/index.d.ts#L169

**Related issue (if exists):**
