### PR TITLE
Fix type of "ref" property on custom component

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -361,7 +361,7 @@ export class Stage extends React.Component<_ReactPixi.IStage> {}
 export const PixiComponent: <Props, PixiInstance extends PIXI.DisplayObject>(
   componentName: string,
   lifecycle: _ReactPixi.ICustomComponent<Props, PixiInstance>
-) => React.ComponentClass<Props>;
+) => React.FC<Props & { ref?: React.Ref<PixiInstance> }>;
 
 /**
  * Tap into the {PIXI.Application} ticker raf.


### PR DESCRIPTION
**Description:**

The type of "ref" property on the class component always be a reference to an instance of a class component. But in react-pixi, it's a Pixi instance, so should set it to a function component and specify the type of ref property.

**Related issue (if exists):**
