### PR TITLE
Unmount sub children

### DIFF
--- a/src/reconciler/hostconfig.js
+++ b/src/reconciler/hostconfig.js
@@ -30,6 +30,13 @@ function removeChild(parent, child) {
     child.willUnmount.call(child, child, parent)
   }
 
+  // unmount potential children
+  if (child.children?.length) {
+    ;[...child.children].forEach(c => {
+      removeChild(child, c)
+    })
+  }
+
   parent.removeChild(child)
   child.destroy()
 }

--- a/test/reconciler.test.js
+++ b/test/reconciler.test.js
@@ -1,4 +1,4 @@
-import React, { Suspense } from 'react'
+import React, { createRef, Suspense } from 'react'
 import * as PIXI from 'pixi.js'
 import { render, roots } from '../src/render'
 import hostconfig from '../src/reconciler/hostconfig'
@@ -98,6 +98,42 @@ describe('reconciler', () => {
       const m = getCall(hostconfig.removeChild)
       expect(m.fn).toHaveBeenCalledTimes(2)
       expect(m.all.map(([_, ins]) => ins.text)).toEqual(['two', 'three'])
+    })
+
+    test('remove sub children', () => {
+      const a = createRef()
+      const b = createRef()
+      const c = createRef()
+      const d = createRef()
+
+      renderInContainer(
+        <Container>
+          <Container>
+            <Text ref={a} />
+            <Text ref={b} />
+            <Text ref={c} />
+            <Text ref={d} />
+          </Container>
+        </Container>
+      )
+
+      a.current.torem = 'a'
+      b.current.torem = 'b'
+      c.current.torem = 'c'
+      d.current.torem = 'd'
+
+      // assign willUnmounts
+      const spyA = (a.current['willUnmount'] = jest.fn())
+      const spyB = (b.current['willUnmount'] = jest.fn())
+      const spyC = (c.current['willUnmount'] = jest.fn())
+      const spyD = (d.current['willUnmount'] = jest.fn())
+
+      renderInContainer(<Container />)
+
+      expect(spyA).toHaveBeenCalled()
+      expect(spyB).toHaveBeenCalled()
+      expect(spyC).toHaveBeenCalled()
+      expect(spyD).toHaveBeenCalled()
     })
 
     test('insert before', () => {


### PR DESCRIPTION
Native components, I.e. `<Sprite>`, `<Graphics>`, etc (including `PixiComponent`) are handled as raw components and are internally not really React components, they return a PIXI instance back to the reconciler.

The problem is that if you have a nested component that relies on a `willUnmount` this might never be triggered. 

Thanks @femetrie for discovering this. 

Fixes #257

This PR calls `willUnmount` on every sequential child that acts as a native component.

