### PR TITLE
Updated animated.d.ts to point to correct type references

### DIFF
--- a/animated/animated.d.ts
+++ b/animated/animated.d.ts
@@ -1,6 +1,6 @@
 import * as PIXI from 'pixi.js';
 import * as React from 'react';
-import { ElementType, ComponentPropsWithRef } from '@react-spring/shared';
+import { ElementType, ComponentPropsWithRef } from '@react-spring/types';
 import { AnimatedProps } from 'react-spring';
 
 type AnimatedComponent<T extends ElementType> = React.ForwardRefExoticComponent<AnimatedProps<ComponentPropsWithRef<T>>>;

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "prop-types": "15.7.2",
     "react": "17.0.2",
     "react-dom": "17.0.2",
-    "react-spring": "9.0.0",
+    "react-spring": "9.1.2",
     "react-test-renderer": "17.0.2",
     "rimraf": "3.0.2",
     "rollup": "2.44.0",
@@ -102,7 +102,7 @@
     "prop-types": "^15.7.2",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
-    "react-spring": "^9.0.0"
+    "react-spring": "^9.1.2"
   },
   "dependencies": {
     "performance-now": "2.1.0",


### PR DESCRIPTION
**Description:**
Updated dependencies in `package.json` to use latest version of react-spring (9.1.2).  react-spring types used in `animated.d.ts` have been moved from `react-spring/shared` to `react-spring/types` The current version with the latest version of `react-spring` causes a build error:

![image](https://user-images.githubusercontent.com/43784132/116565675-fd03a980-a8fd-11eb-9c61-57afa998babf.png)

https://github.com/pmndrs/react-spring/commit/d4e582a9a879a67ff3d54d41a15318dfde16cefd#diff-843ed19e8a4e3e5d73431ff372cfeb3d9dcf02742775499b93ccb84bf11633b5