### PR TITLE
Fix assignment of missing config object

### DIFF
--- a/src/utils/element.js
+++ b/src/utils/element.js
@@ -56,6 +56,7 @@ export function createElement(type, props = {}, root = null) {
       instance.didMount = injected.didMount ? injected.didMount.bind(instance) : undefined
       instance.willUnmount = injected.willUnmount ? injected.willUnmount.bind(instance) : undefined
       instance.applyProps = injected.applyProps ? injected.applyProps.bind(instance) : undefined
+      instance.config = injected.config
     }
   }
 

--- a/test/element.spec.js
+++ b/test/element.spec.js
@@ -295,6 +295,10 @@ describe('PixiComponent', () => {
 
   test('create injected component', () => {
     const scoped = jest.fn()
+    const config = {
+      destroyChildren: true,
+      destroy: true
+    }
 
     const lifecycle = {
       create: jest.fn(() => new PIXI.Graphics()),
@@ -303,6 +307,7 @@ describe('PixiComponent', () => {
       applyProps: jest.fn(function () {
         scoped(this)
       }),
+      config: config
     }
 
     new PixiComponent('Rectangle', lifecycle)
@@ -313,6 +318,7 @@ describe('PixiComponent', () => {
     expect(element.didMount).toBeDefined()
     expect(element.willUnmount).toBeDefined()
     expect(element.applyProps).toBeDefined()
+    expect(element.config).toBe(config)
     expect(element).toBeInstanceOf(PIXI.Graphics)
     expect(lifecycle.create).toHaveBeenCalledTimes(1)
     expect(lifecycle.create).toHaveBeenCalledWith(props)


### PR DESCRIPTION
**Description:**
When destroying, config is not assigned.

**Related issue (if exists):**
https://github.com/inlet/react-pixi/issues/303