### PR TITLE
Support Federated Events API

### DIFF
--- a/src/stage/index.js
+++ b/src/stage/index.js
@@ -209,6 +209,8 @@ class Stage extends React.Component {
   }
 
   resetInteractionManager() {
+    // `interaction` property could be absent if user has installed Federated Events API plugin.
+    // https://api.pixijs.io/@pixi/events.html
     if ('interaction' in this.app.renderer.plugins) {
       this.app.renderer.plugins.interaction.resolution = this.app.renderer.resolution
     }

--- a/src/stage/index.js
+++ b/src/stage/index.js
@@ -209,7 +209,9 @@ class Stage extends React.Component {
   }
 
   resetInteractionManager() {
-    this.app.renderer.plugins.interaction.resolution = this.app.renderer.resolution
+    if ('interaction' in this.app.renderer.plugins) {
+      this.app.renderer.plugins.interaction.resolution = this.app.renderer.resolution
+    }
   }
 
   getChildren() {

--- a/test/stage.spec.js
+++ b/test/stage.spec.js
@@ -333,6 +333,7 @@ describe('stage', () => {
     })
 
     test('does not update resolution of interaction plugin if interaction plugin is removed', () => {
+      const interaction = PIXI.Renderer.__plugins.interaction
       delete PIXI.Renderer.__plugins.interaction
 
       let el = renderer.create(<Stage width={800} height={600} options={{ resolution: 1 }} />)
@@ -343,6 +344,8 @@ describe('stage', () => {
       expect(() => el.update(<Stage width={800} height={600} options={{ resolution: 2 }} />)).not.toThrow()
       expect(spyResize).toHaveBeenCalledWith(800, 600)
       expect(appRenderer.resolution).toEqual(2)
+
+      PIXI.Renderer.__plugins.interaction = interaction
     })
 
     test('clean up media query on unmount', () => {

--- a/test/stage.spec.js
+++ b/test/stage.spec.js
@@ -332,6 +332,19 @@ describe('stage', () => {
       expect(appRenderer.resolution).toEqual(2)
     })
 
+    test('does not update resolution of interaction plugin if interaction plugin is removed', () => {
+      delete PIXI.Renderer.__plugins.interaction
+
+      let el = renderer.create(<Stage width={800} height={600} options={{ resolution: 1 }} />)
+
+      const appRenderer = el.getInstance().app.renderer
+      const spyResize = jest.spyOn(appRenderer, 'resize')
+
+      expect(() => el.update(<Stage width={800} height={600} options={{ resolution: 2 }} />)).not.toThrow()
+      expect(spyResize).toHaveBeenCalledWith(800, 600)
+      expect(appRenderer.resolution).toEqual(2)
+    })
+
     test('clean up media query on unmount', () => {
       let el = renderer.create(
         <div>


### PR DESCRIPTION
**Description:**

This PR prevents an error when using react-pixi with @pixi/events plugin.

**Related issue (if exists):**
#333