### PR TITLE
Move update events from window to root container

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ examples/
 .docz/
 .yarn-error.log
 docs/
+.idea

--- a/src/components/NineSlicePlane.js
+++ b/src/components/NineSlicePlane.js
@@ -3,7 +3,7 @@ import { getTextureFromProps, applyDefaultProps } from '../utils/props'
 
 const NineSlicePlane = (root, props) => {
   const { leftWidth = 10, topHeight = 10, rightWidth = 10, bottomHeight = 10 } = props
-  const texture = getTextureFromProps('NineSlicePlane', props)
+  const texture = getTextureFromProps('NineSlicePlane', root, props)
 
   const nineSlicePlane = new PixiNineSlicePlane(texture, leftWidth, topHeight, rightWidth, bottomHeight)
 
@@ -16,7 +16,7 @@ const NineSlicePlane = (root, props) => {
       if (texture !== oldProps.texture) {
         changed = true
       }
-      instance.texture = getTextureFromProps('NineSlicePlane', newProps)
+      instance.texture = getTextureFromProps('NineSlicePlane', root, newProps)
     }
 
     return changed

--- a/src/components/SimpleMesh.js
+++ b/src/components/SimpleMesh.js
@@ -2,7 +2,7 @@ import { SimpleMesh as PixiSimpleMesh, DRAW_MODES } from 'pixi.js'
 import { applyDefaultProps, getTextureFromProps } from '../utils/props'
 
 const SimpleMesh = (root, props) => {
-  const texture = getTextureFromProps('Mesh', props)
+  const texture = getTextureFromProps('Mesh', root, props)
   const { vertices, uvs, indices, drawMode = DRAW_MODES.TRIANGLES } = props
 
   const simpleMesh = new PixiSimpleMesh(texture, vertices, uvs, indices, drawMode)
@@ -16,7 +16,7 @@ const SimpleMesh = (root, props) => {
       if (texture !== oldProps.texture) {
         changed = true
       }
-      instance.texture = getTextureFromProps('Mesh', newProps)
+      instance.texture = getTextureFromProps('Mesh', root, newProps)
     }
 
     return changed

--- a/src/components/SimpleRope.js
+++ b/src/components/SimpleRope.js
@@ -3,7 +3,7 @@ import invariant from '../utils/invariant'
 import { getTextureFromProps, applyDefaultProps } from '../utils/props'
 
 const SimpleRope = (root, props) => {
-  const texture = getTextureFromProps('SimpleRope', props)
+  const texture = getTextureFromProps('SimpleRope', root, props)
   const { points } = props
 
   const rope = new PixiSimpleRope(texture, points)
@@ -18,7 +18,7 @@ const SimpleRope = (root, props) => {
       if (texture !== oldProps.texture) {
         changed = true
       }
-      instance.texture = getTextureFromProps('SimpleRope', newProps)
+      instance.texture = getTextureFromProps('SimpleRope', root, newProps)
     }
 
     return changed

--- a/src/components/Sprite.js
+++ b/src/components/Sprite.js
@@ -2,7 +2,7 @@ import { Sprite as PixiSprite } from 'pixi.js'
 import { getTextureFromProps, applyDefaultProps } from '../utils/props'
 
 const Sprite = (root, props) => {
-  const sprite = new PixiSprite(getTextureFromProps('Sprite', props))
+  const sprite = new PixiSprite(getTextureFromProps('Sprite', root, props))
 
   sprite.applyProps = (instance, oldProps, newProps) => {
     const { image, texture, ...props } = newProps
@@ -13,7 +13,7 @@ const Sprite = (root, props) => {
       if (oldProps.texture !== newProps.texture) {
         changed = true
       }
-      instance.texture = getTextureFromProps('Sprite', newProps)
+      instance.texture = getTextureFromProps('Sprite', root, newProps)
     }
 
     return changed

--- a/src/components/TilingSprite.js
+++ b/src/components/TilingSprite.js
@@ -4,7 +4,7 @@ import { parsePoint, pointsAreEqual } from '../utils/pixi'
 
 const TilingSprite = (root, props) => {
   const { width = 100, height = 100 } = props
-  const texture = getTextureFromProps('TilingSprite', props)
+  const texture = getTextureFromProps('TilingSprite', root, props)
 
   const ts = new PixiTilingSprite(texture, width, height)
 
@@ -30,7 +30,7 @@ const TilingSprite = (root, props) => {
         changed = true
       }
 
-      instance.texture = getTextureFromProps('Sprite', newProps)
+      instance.texture = getTextureFromProps('Sprite', root, newProps)
     }
 
     return changed

--- a/src/reconciler/hostconfig.js
+++ b/src/reconciler/hostconfig.js
@@ -208,31 +208,31 @@ const HostConfig = {
 
   appendInitialChild(...args) {
     const res = appendChild.apply(null, args)
-    window.dispatchEvent(new CustomEvent(`__REACT_PIXI_REQUEST_RENDER__`, { detail: 'appendInitialChild' }))
+    args[0].__reactpixi?.root?.emit(`__REACT_PIXI_REQUEST_RENDER__`, { detail: 'appendInitialChild' })
     return res
   },
 
   appendChild(...args) {
     const res = appendChild.apply(null, args)
-    window.dispatchEvent(new CustomEvent(`__REACT_PIXI_REQUEST_RENDER__`, { detail: 'appendChild' }))
+    args[0].__reactpixi?.root?.emit(`__REACT_PIXI_REQUEST_RENDER__`, { detail: 'appendChild' })
     return res
   },
 
   appendChildToContainer(...args) {
     const res = appendChild.apply(null, args)
-    window.dispatchEvent(new CustomEvent(`__REACT_PIXI_REQUEST_RENDER__`, { detail: 'appendChildToContainer' }))
+    args[0].__reactpixi?.root?.emit(`__REACT_PIXI_REQUEST_RENDER__`, { detail: 'appendChildToContainer' })
     return res
   },
 
   removeChild(...args) {
     const res = removeChild.apply(null, args)
-    window.dispatchEvent(new CustomEvent(`__REACT_PIXI_REQUEST_RENDER__`, { detail: 'removeChild' }))
+    args[0].__reactpixi?.root?.emit(`__REACT_PIXI_REQUEST_RENDER__`, { detail: 'removeChild' })
     return res
   },
 
   removeChildFromContainer(...args) {
     const res = removeChild.apply(null, args)
-    window.dispatchEvent(new CustomEvent(`__REACT_PIXI_REQUEST_RENDER__`, { detail: 'removeChildFromContainer' }))
+    args[0].__reactpixi?.root?.emit(`__REACT_PIXI_REQUEST_RENDER__`, { detail: 'removeChildFromContainer' })
     return res
   },
 
@@ -240,7 +240,7 @@ const HostConfig = {
 
   insertInContainerBefore(...args) {
     const res = insertBefore.apply(null, args)
-    window.dispatchEvent(new CustomEvent(`__REACT_PIXI_REQUEST_RENDER__`, { detail: 'insertInContainerBefore' }))
+    args[0].__reactpixi?.root?.emit(`__REACT_PIXI_REQUEST_RENDER__`, { detail: 'insertInContainerBefore' })
     return res
   },
 
@@ -252,7 +252,7 @@ const HostConfig = {
 
     const changed = applyProps(instance, oldProps, newProps)
     if (changed || prepareChanged) {
-      window.dispatchEvent(new CustomEvent(`__REACT_PIXI_REQUEST_RENDER__`, { detail: 'commitUpdate' }))
+      instance.__reactpixi?.root?.emit(`__REACT_PIXI_REQUEST_RENDER__`, { detail: 'commitUpdate' })
     }
   },
 

--- a/src/stage/Stage.mdx
+++ b/src/stage/Stage.mdx
@@ -99,6 +99,8 @@ This might result in faster running cooling fans on your computer due the overhe
 
 ### Update stage on React component changes
 
+If you want to know when components have changed, you can listen to the `__REACT_PIXI_REQUEST_RENDER__` event on the root container (app.stage).
+
 > Disable `raf` and enable `renderOnComponentChange`:
 
 <Playground>

--- a/src/stage/index.js
+++ b/src/stage/index.js
@@ -140,7 +140,7 @@ class Stage extends React.Component {
       this._ticker = new Ticker()
       this._ticker.autoStart = true
       this._ticker.add(this.renderStage)
-      window.addEventListener('__REACT_PIXI_REQUEST_RENDER__', this.needsRenderUpdate)
+      this.app.stage.on('__REACT_PIXI_REQUEST_RENDER__', this.needsRenderUpdate)
     }
 
     this.updateSize()
@@ -235,7 +235,7 @@ class Stage extends React.Component {
       this._ticker.destroy()
     }
 
-    window.removeEventListener('__REACT_PIXI_REQUEST_RENDER__', this.needsRenderUpdate)
+    this.app.stage.off('__REACT_PIXI_REQUEST_RENDER__', this.needsRenderUpdate)
 
     PixiFiber.updateContainer(null, this.mountNode, this)
 

--- a/src/stage/index.js
+++ b/src/stage/index.js
@@ -123,6 +123,7 @@ class Stage extends React.Component {
     this.app.ticker.autoStart = false
     this.app.ticker[raf ? 'start' : 'stop']()
 
+    this.app.stage.__reactpixi = { root: this.app.stage }
     this.mountNode = PixiFiber.createContainer(this.app.stage)
     PixiFiber.updateContainer(this.getChildren(), this.mountNode, this)
 

--- a/src/utils/element.js
+++ b/src/utils/element.js
@@ -64,6 +64,10 @@ export function createElement(type, props = {}, root = null) {
   if (instance) {
     applyProps = typeof instance?.applyProps === 'function' ? instance.applyProps : applyDefaultProps
     applyProps(instance, {}, props)
+
+    instance.__reactpixi = {
+      root,
+    }
   }
 
   return instance

--- a/src/utils/props.js
+++ b/src/utils/props.js
@@ -50,10 +50,11 @@ export const PROPS_DISPLAY_OBJECT = {
  * Can be either texture or image
  *
  * @param {string} elementType
+ * @param {PIXI.Container} root
  * @param {object} props
  * @returns {PIXI.Texture|null}
  */
-export const getTextureFromProps = (elementType, props = {}) => {
+export const getTextureFromProps = (elementType, root, props = {}) => {
   const emitChange = texture =>
     requestAnimationFrame(() => {
       texture?.__reactpixi?.root?.emit(`__REACT_PIXI_REQUEST_RENDER__`)
@@ -84,6 +85,7 @@ export const getTextureFromProps = (elementType, props = {}) => {
     invariant(!!result, `${elementType} could not get texture from props`)
 
     const texture = Texture.from(result)
+    texture.__reactpixi = { root }
     texture.once('update', emitChange)
     texture.once('loaded', emitChange)
 

--- a/src/utils/props.js
+++ b/src/utils/props.js
@@ -54,9 +54,9 @@ export const PROPS_DISPLAY_OBJECT = {
  * @returns {PIXI.Texture|null}
  */
 export const getTextureFromProps = (elementType, props = {}) => {
-  const emitChange = () =>
+  const emitChange = texture =>
     requestAnimationFrame(() => {
-      window.dispatchEvent(new CustomEvent('__REACT_PIXI_REQUEST_RENDER__'))
+      texture?.__reactpixi?.root?.emit(`__REACT_PIXI_REQUEST_RENDER__`)
     })
 
   const check = (inType, validator) => {
@@ -88,7 +88,7 @@ export const getTextureFromProps = (elementType, props = {}) => {
     texture.once('loaded', emitChange)
 
     if (texture.valid) {
-      emitChange()
+      emitChange(texture)
     }
 
     return texture

--- a/test/props.spec.js
+++ b/test/props.spec.js
@@ -22,55 +22,55 @@ describe('props', () => {
     })
 
     test('invariant image', () => {
-      expect(() => getTextureFromProps('Test', { image: 123 })).toThrow('Test image prop is invalid')
+      expect(() => getTextureFromProps('Test', undefined, { image: 123 })).toThrow('Test image prop is invalid')
     })
 
     test('invariant texture', () => {
-      expect(() => getTextureFromProps('Test', { texture: 'texture' })).toThrow(
+      expect(() => getTextureFromProps('Test', undefined, { texture: 'texture' })).toThrow(
         'Test texture needs to be typeof `PIXI.Texture`'
       )
     })
 
     test('invariant video', () => {
-      expect(() => getTextureFromProps('Test', { video: 123 })).toThrow('Test video prop is invalid')
+      expect(() => getTextureFromProps('Test', undefined, { video: 123 })).toThrow('Test video prop is invalid')
     })
 
     test('invariant source', () => {
-      expect(() => getTextureFromProps('Test', { source: null })).toThrow('Test source prop is invalid')
+      expect(() => getTextureFromProps('Test', undefined, { source: null })).toThrow('Test source prop is invalid')
     })
 
     test('get texture from image url', () => {
-      const texture = getTextureFromProps('Test', { image: './image.png' })
+      const texture = getTextureFromProps('Test', undefined, { image: './image.png' })
       expect(texture).toBeInstanceOf(PIXI.Texture)
       expect(spy).toBeCalledWith('./image.png')
     })
 
     test('get texture from image html element', () => {
       const image = document.createElement('img')
-      const texture = getTextureFromProps('Test', { image })
+      const texture = getTextureFromProps('Test', undefined, { image })
       expect(texture).toBeInstanceOf(PIXI.Texture)
       expect(spy).toBeCalledWith(image)
     })
 
     test('get texture from video url', () => {
-      const texture = getTextureFromProps('Test', { video: './video.mp4' })
+      const texture = getTextureFromProps('Test', undefined, { video: './video.mp4' })
       expect(texture).toBeInstanceOf(PIXI.Texture)
       expect(spy).toBeCalledWith('./video.mp4')
     })
 
     test('get texture from video html element', () => {
       const video = document.createElement('video')
-      const texture = getTextureFromProps('Test', { video })
+      const texture = getTextureFromProps('Test', undefined, { video })
       expect(texture).toBeInstanceOf(PIXI.Texture)
       expect(spy).toBeCalledWith(video)
     })
 
     test('get no texture', () => {
-      expect(() => getTextureFromProps('Test', {})).toThrow('Test could not get texture from props')
+      expect(() => getTextureFromProps('Test', undefined, {})).toThrow('Test could not get texture from props')
     })
 
     test('get texture from texture', () => {
-      const texture = getTextureFromProps('Test', { texture: emptyTexture })
+      const texture = getTextureFromProps('Test', undefined, { texture: emptyTexture })
       expect(texture).toBe(emptyTexture)
     })
   })

--- a/test/reconciler.test.js
+++ b/test/reconciler.test.js
@@ -424,25 +424,57 @@ describe('reconciler', () => {
   })
 
   describe('emits request render', () => {
-    let spy = jest.fn()
+    let spy1 = jest.fn()
+    let spy2 = jest.fn()
+
+    let container2 = new PIXI.Container()
+    container2.root = true
+    const renderInContainer2 = comp => render(comp, container2)
 
     beforeEach(() => {
-      spy.mockReset()
-      container.on('__REACT_PIXI_REQUEST_RENDER__', spy)
+      spy1.mockReset()
+      spy2.mockReset()
+      container.on('__REACT_PIXI_REQUEST_RENDER__', spy1)
+      container2.on('__REACT_PIXI_REQUEST_RENDER__', spy2)
+
     })
 
     afterEach(() => {
-      container.off('__REACT_PIXI_REQUEST_RENDER__', spy)
+      container.off('__REACT_PIXI_REQUEST_RENDER__', spy1)
+      container2.off('__REACT_PIXI_REQUEST_RENDER__', spy2)
     })
 
-    it('receives request events via `window` object', function () {
+    it('receives request events via root container', function () {
       renderInContainer(
         <Container>
           <Text text="one" />
         </Container>
       )
 
-      expect(spy).toHaveBeenCalled()
+      expect(spy1).toHaveBeenCalled()
+    })
+
+    it('receives different events in different containers', function () {
+      renderInContainer(
+        <Container>
+          <Text text="one" />
+        </Container>
+      )
+
+      renderInContainer2(
+        <Container>
+          <Text text="one" />
+        </Container>
+      )
+
+      renderInContainer2(
+        <Container>
+          <Text text="two" />
+        </Container>
+      )
+
+      expect(spy1).toHaveBeenCalledTimes(1)
+      expect(spy2).toHaveBeenCalledTimes(2)
     })
   })
 })

--- a/test/reconciler.test.js
+++ b/test/reconciler.test.js
@@ -428,11 +428,11 @@ describe('reconciler', () => {
 
     beforeEach(() => {
       spy.mockReset()
-      window.addEventListener('__REACT_PIXI_REQUEST_RENDER__', spy)
+      container.on('__REACT_PIXI_REQUEST_RENDER__', spy)
     })
 
     afterEach(() => {
-      window.removeEventListener('__REACT_PIXI_REQUEST_RENDER__', spy)
+      container.off('__REACT_PIXI_REQUEST_RENDER__', spy)
     })
 
     it('receives request events via `window` object', function () {


### PR DESCRIPTION
<!--
Thank you very much for your pull request!
-->

**Description:**
I've didn't manage to get the canvas instance from the hostconfig where events were emitted from, so I've basically done what react-three-fiber does: I store the root container in each pixi component. Not so elegant solution, but iterating through all branch of the tree to find root node seems a bit overhead. Also, I didn't add any new tests, bc I don't see any necessity.
Maybe I should leave old window.dispatchEvent for backwards compatibility? Ideally I'd hide this behind some kind of global flag, but I don't know how to do it good.

**Related issue (if exists):**
#339 