### PR TITLE
fix: check if app.renderer is not null before calling destroy()

### DIFF
--- a/src/helpers/unmountRoot.ts
+++ b/src/helpers/unmountRoot.ts
@@ -13,7 +13,7 @@ export function unmountRoot(root: Root)
     {
         reconciler.updateContainer(null, fiber, null, () =>
         {
-            if (root.applicationState.app)
+            if (root.applicationState.app.renderer !== null)
             {
                 root.applicationState.app.destroy();
             }


### PR DESCRIPTION
When `destroy()` is called, Pixi.js sets `renderer` to `null` (see the source at https://github.com/pixijs/pixijs/blob/f60121308acbba32f81333a7918c3a4998172885/src/app/Application.ts#L416).

Because React.StrictMode may invoke the "unmount" helper twice during development, this can results in a crash.