### PR TITLE
fix: pass DevTools config through createReconciler

### DIFF
--- a/src/core/reconciler.ts
+++ b/src/core/reconciler.ts
@@ -116,6 +116,7 @@ const reconciler = createReconciler<
     HostConfig['transitionStatus']
 >(reconcilerConfig);
 
+// @ts-expect-error -- reconciler types are out of date, remove when fixed
 reconciler.injectIntoDevTools();
 
 export { reconciler };


### PR DESCRIPTION
Should fix: https://github.com/pixijs/pixi-react/issues/631

We had the same issue in @react-three/fiber 
And this PR fix it https://github.com/pmndrs/react-three-fiber/pull/3594

I found out that injectIntoDevTools is not the correct way to pass the DevTools config anymore. It changed in that PR https://github.com/facebook/react/pull/30522/files

I did not test this PR as I'm not familiar with your repo but it should work for you too 👍 