### PR TITLE
chore: publish preview packages for pull requests

### DIFF
--- a/.github/workflows/handle-release-branch-push.yml
+++ b/.github/workflows/handle-release-branch-push.yml
@@ -64,7 +64,6 @@ jobs:
 
       - name: Publish
         run: npx pkg-pr-new@latest publish --no-template
-    
   publish:
     name: 'Publish: Release'
     needs:


### PR DESCRIPTION
## Publish Preview Packages

Following pixi.js setup of stackblitz/pkg.pr.new -> https://github.com/pixijs/pixijs/pull/11571

Adding a few templates would be a nice touch, for now this is mainly to help with unblocking testing PRs against existing projects.