### PR TITLE
feat: support React 19.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,8 +12,7 @@
         "docs"
       ],
       "dependencies": {
-        "its-fine": "^2.0.0",
-        "react-reconciler": "0.31.0"
+        "its-fine": "^2.0.0"
       },
       "devDependencies": {
         "@pixi/extension-scripts": "^4.0.0",
@@ -23,8 +22,9 @@
         "@testing-library/jest-dom": "^6.4.8",
         "@testing-library/react": "^16.1.0",
         "@testing-library/user-event": "^14.5.2",
-        "@types/react": "^19.0.0",
-        "@types/react-reconciler": "^0.28.9",
+        "@types/react": "^19.2.7",
+        "@types/react-dom": "^19.2.3",
+        "@types/react-reconciler": "^0.32.3",
         "@vitejs/plugin-react": "^4.3.1",
         "@vitest/browser": "^2.0.4",
         "eslint-plugin-react-hooks": "^5.2.0",
@@ -32,8 +32,9 @@
         "jsdom": "^25.0.0",
         "pixi.js": "8.2.6",
         "playwright": "^1.45.3",
-        "react": "^19.0.0",
-        "react-dom": "^19.0.0",
+        "react": "^19.2.0",
+        "react-dom": "^19.2.0",
+        "react-reconciler": "^0.33.0",
         "rollup": "^4.18.0",
         "rollup-plugin-esbuild": "^6.1.1",
         "rollup-plugin-inject-process-env": "^1.3.1",
@@ -44,7 +45,7 @@
       },
       "peerDependencies": {
         "pixi.js": "^8.2.6",
-        "react": ">=19.0.0"
+        "react": ">=19 <19.3"
       }
     },
     "docs": {
@@ -91,6 +92,15 @@
         "react": ">=19.0.0"
       }
     },
+    "docs/node_modules/@types/react-reconciler": {
+      "version": "0.28.9",
+      "resolved": "https://registry.npmjs.org/@types/react-reconciler/-/react-reconciler-0.28.9.tgz",
+      "integrity": "sha512-HHM3nxyUZ3zAylX8ZEyrDNd2XZOnQ0D5XfunJF5FLQnZbHHYq4UWvW1QfelQNXv1ICNkwYhfxjwfnqivYB6bFg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*"
+      }
+    },
     "docs/node_modules/its-fine": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/its-fine/-/its-fine-1.2.5.tgz",
@@ -101,6 +111,21 @@
       },
       "peerDependencies": {
         "react": ">=18.0"
+      }
+    },
+    "docs/node_modules/react-reconciler": {
+      "version": "0.31.0",
+      "resolved": "https://registry.npmjs.org/react-reconciler/-/react-reconciler-0.31.0.tgz",
+      "integrity": "sha512-7Ob7Z+URmesIsIVRjnLoDGwBEG/tVitidU0nMsqX/eeJaLY89RISO/10ERe0MqmzuKUUB1rmY+h1itMbUHg9BQ==",
+      "license": "MIT",
+      "dependencies": {
+        "scheduler": "^0.25.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "peerDependencies": {
+        "react": "^19.0.0"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -9385,18 +9410,29 @@
       "license": "MIT"
     },
     "node_modules/@types/react": {
-      "version": "19.0.8",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.0.8.tgz",
-      "integrity": "sha512-9P/o1IGdfmQxrujGbIMDyYaaCykhLKc0NGCtYcECNUr9UAaDe4gwvV9bR6tvd5Br1SG0j+PBpbKr2UYY8CwqSw==",
+      "version": "19.2.7",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.7.tgz",
+      "integrity": "sha512-MWtvHrGZLFttgeEj28VXHxpmwYbor/ATPYbBfSFZEIRK0ecCFLl2Qo55z52Hss+UV9CRN7trSeq1zbgx7YDWWg==",
       "license": "MIT",
       "dependencies": {
-        "csstype": "^3.0.2"
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "19.2.3",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
+      "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^19.2.0"
       }
     },
     "node_modules/@types/react-reconciler": {
-      "version": "0.28.9",
-      "resolved": "https://registry.npmjs.org/@types/react-reconciler/-/react-reconciler-0.28.9.tgz",
-      "integrity": "sha512-HHM3nxyUZ3zAylX8ZEyrDNd2XZOnQ0D5XfunJF5FLQnZbHHYq4UWvW1QfelQNXv1ICNkwYhfxjwfnqivYB6bFg==",
+      "version": "0.32.3",
+      "resolved": "https://registry.npmjs.org/@types/react-reconciler/-/react-reconciler-0.32.3.tgz",
+      "integrity": "sha512-cMi5ZrLG7UtbL7LTK6hq9w/EZIRk4Mf1Z5qHoI+qBh7/WkYkFXQ7gOto2yfUvPzF5ERMAhaXS5eTQ2SAnHjLzA==",
+      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "*"
@@ -14626,9 +14662,9 @@
       "license": "MIT"
     },
     "node_modules/csstype": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
-      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "license": "MIT"
     },
     "node_modules/d": {
@@ -20587,6 +20623,15 @@
       },
       "peerDependencies": {
         "react": "^19.0.0"
+      }
+    },
+    "node_modules/its-fine/node_modules/@types/react-reconciler": {
+      "version": "0.28.9",
+      "resolved": "https://registry.npmjs.org/@types/react-reconciler/-/react-reconciler-0.28.9.tgz",
+      "integrity": "sha512-HHM3nxyUZ3zAylX8ZEyrDNd2XZOnQ0D5XfunJF5FLQnZbHHYq4UWvW1QfelQNXv1ICNkwYhfxjwfnqivYB6bFg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*"
       }
     },
     "node_modules/jackspeak": {
@@ -29525,9 +29570,9 @@
       }
     },
     "node_modules/react": {
-      "version": "19.0.0",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.0.0.tgz",
-      "integrity": "sha512-V8AVnmPIICiWpGfm6GLzCR/W5FXLchHop40W4nXBmdlEceh16rCN8O8LNWm5bh5XUX91fh7KpA+W0TgMKmgTpQ==",
+      "version": "19.2.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.0.tgz",
+      "integrity": "sha512-tmbWg6W31tQLeB5cdIBOicJDJRR2KzXsV7uSK9iNfLWQ5bIZfxuPEHp7M8wiHyHnn0DD1i7w3Zmin0FtkrwoCQ==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -29734,16 +29779,22 @@
       }
     },
     "node_modules/react-dom": {
-      "version": "19.0.0",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.0.0.tgz",
-      "integrity": "sha512-4GV5sHFG0e/0AD4X+ySy6UJd3jVl1iNsNHdpad0qhABJ11twS3TTBnseqsKurKcsNqCEFeGL3uLpVChpIO3QfQ==",
+      "version": "19.2.0",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.0.tgz",
+      "integrity": "sha512-UlbRu4cAiGaIewkPyiRGJk0imDN2T3JjieT6spoL2UeSf5od4n5LB/mQ4ejmxhCFT1tYe8IvaFulzynWovsEFQ==",
       "license": "MIT",
       "dependencies": {
-        "scheduler": "^0.25.0"
+        "scheduler": "^0.27.0"
       },
       "peerDependencies": {
-        "react": "^19.0.0"
+        "react": "^19.2.0"
       }
+    },
+    "node_modules/react-dom/node_modules/scheduler": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+      "license": "MIT"
     },
     "node_modules/react-error-overlay": {
       "version": "6.0.11",
@@ -29811,19 +29862,27 @@
       }
     },
     "node_modules/react-reconciler": {
-      "version": "0.31.0",
-      "resolved": "https://registry.npmjs.org/react-reconciler/-/react-reconciler-0.31.0.tgz",
-      "integrity": "sha512-7Ob7Z+URmesIsIVRjnLoDGwBEG/tVitidU0nMsqX/eeJaLY89RISO/10ERe0MqmzuKUUB1rmY+h1itMbUHg9BQ==",
+      "version": "0.33.0",
+      "resolved": "https://registry.npmjs.org/react-reconciler/-/react-reconciler-0.33.0.tgz",
+      "integrity": "sha512-KetWRytFv1epdpJc3J4G75I4WrplZE5jOL7Yq0p34+OVOKF4Se7WrdIdVC45XsSSmUTlht2FM/fM1FZb1mfQeA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
-        "scheduler": "^0.25.0"
+        "scheduler": "^0.27.0"
       },
       "engines": {
         "node": ">=0.10.0"
       },
       "peerDependencies": {
-        "react": "^19.0.0"
+        "react": "^19.2.0"
       }
+    },
+    "node_modules/react-reconciler/node_modules/scheduler": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/react-refresh": {
       "version": "0.14.2",

--- a/package.json
+++ b/package.json
@@ -68,8 +68,7 @@
     ]
   },
   "dependencies": {
-    "its-fine": "^2.0.0",
-    "react-reconciler": "0.31.0"
+    "its-fine": "^2.0.0"
   },
   "devDependencies": {
     "@pixi/extension-scripts": "^4.0.0",
@@ -79,8 +78,9 @@
     "@testing-library/jest-dom": "^6.4.8",
     "@testing-library/react": "^16.1.0",
     "@testing-library/user-event": "^14.5.2",
-    "@types/react": "^19.0.0",
-    "@types/react-reconciler": "^0.28.9",
+    "@types/react": "^19.2.7",
+    "@types/react-dom": "^19.2.3",
+    "@types/react-reconciler": "^0.32.3",
     "@vitejs/plugin-react": "^4.3.1",
     "@vitest/browser": "^2.0.4",
     "eslint-plugin-react-hooks": "^5.2.0",
@@ -88,8 +88,9 @@
     "jsdom": "^25.0.0",
     "pixi.js": "8.2.6",
     "playwright": "^1.45.3",
-    "react": "^19.0.0",
-    "react-dom": "^19.0.0",
+    "react": "^19.2.0",
+    "react-dom": "^19.2.0",
+    "react-reconciler": "^0.33.0",
     "rollup": "^4.18.0",
     "rollup-plugin-esbuild": "^6.1.1",
     "rollup-plugin-inject-process-env": "^1.3.1",
@@ -100,7 +101,7 @@
   },
   "peerDependencies": {
     "pixi.js": "^8.2.6",
-    "react": ">=19.0.0"
+    "react": ">=19 <19.3"
   },
   "overrides": {
     "rollup": "^4.18.0"

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -16,6 +16,7 @@ const paths = {
 };
 
 const {
+    devDependencies = {},
     dependencies = {},
 } = repo;
 
@@ -52,7 +53,13 @@ function convertPackageNameToRegExp(packageName)
     return new RegExp(`^${escapeRegExp(packageName)}(/.+)?$`);
 }
 
-const external = ({ bundleDeps = false } = {}) => (bundleDeps ? [] : Object.keys(dependencies).map(convertPackageNameToRegExp));
+const external = ({ bundleDeps = false } = {}) =>
+    Object
+        .keys({
+            ...devDependencies, // not installed by users from NPM and must be bundled
+            ...(bundleDeps ? dependencies : {}),
+        })
+        .map(convertPackageNameToRegExp);
 
 const targets = {
     lib: {

--- a/src/core/reconciler.ts
+++ b/src/core/reconciler.ts
@@ -1,47 +1,61 @@
-import packageData from '../../package.json' with { type: 'json' };
-import { afterActiveInstanceBlur } from '../helpers/afterActiveInstanceBlur';
-import { appendChild } from '../helpers/appendChild';
-import { beforeActiveInstanceBlur } from '../helpers/beforeActiveInstanceBlur';
-import { clearContainer } from '../helpers/clearContainer';
-import { commitUpdate } from '../helpers/commitUpdate';
-import { createInstance } from '../helpers/createInstance';
-import { createReconciler } from '../helpers/createReconciler';
-import { createTextInstance } from '../helpers/createTextInstance';
-import { detachDeletedInstance } from '../helpers/detachDeletedInstance';
-import { finalizeInitialChildren } from '../helpers/finalizeInitialChildren';
-import { getChildHostContext } from '../helpers/getChildHostContext';
-import { getCurrentUpdatePriority } from '../helpers/getCurrentUpdatePriority';
-import { getInstanceFromNode } from '../helpers/getInstanceFromNode';
-import { getInstanceFromScope } from '../helpers/getInstanceFromScope';
-import { getPublicInstance } from '../helpers/getPublicInstance';
-import { getRootHostContext } from '../helpers/getRootHostContext';
-import { hideInstance } from '../helpers/hideInstance';
-import { hideTextInstance } from '../helpers/hideTextInstance';
-import { insertBefore } from '../helpers/insertBefore';
-import { maySuspendCommit } from '../helpers/maySuspendCommit';
-import { preloadInstance } from '../helpers/preloadInstance';
-import { prepareForCommit } from '../helpers/prepareForCommit';
-import { preparePortalMount } from '../helpers/preparePortalMount';
-import { prepareScopeUpdate } from '../helpers/prepareScopeUpdate';
-import { removeChild } from '../helpers/removeChild';
-import { requestPostPaintCallback } from '../helpers/requestPostPaintCallback';
-import { resetAfterCommit } from '../helpers/resetAfterCommit';
-import { resetFormInstance } from '../helpers/resetFormInstance';
-import { resolveEventTimeStamp } from '../helpers/resolveEventTimeStamp';
-import { resolveEventType } from '../helpers/resolveEventType';
-import { resolveUpdatePriority } from '../helpers/resolveUpdatePriority';
-import { setCurrentUpdatePriority } from '../helpers/setCurrentUpdatePriority';
-import { shouldAttemptEagerTransition } from '../helpers/shouldAttemptEagerTransition';
-import { shouldSetTextContent } from '../helpers/shouldSetTextContent';
-import { startSuspendingCommit } from '../helpers/startSuspendingCommit';
-import { suspendInstance } from '../helpers/suspendInstance';
-import { trackSchedulerEvent } from '../helpers/trackSchedulerEvent';
-import { unhideInstance } from '../helpers/unhideInstance';
-import { unhideTextInstance } from '../helpers/unhideTextInstance';
-import { waitForCommitToBeReady } from '../helpers/waitForCommitToBeReady';
-import { type HostConfig } from '../typedefs/HostConfig';
+import { afterActiveInstanceBlur } from "../helpers/afterActiveInstanceBlur";
+import { appendChild } from "../helpers/appendChild";
+import { beforeActiveInstanceBlur } from "../helpers/beforeActiveInstanceBlur";
+import { clearContainer } from "../helpers/clearContainer";
+import { commitUpdate } from "../helpers/commitUpdate";
+import { createInstance } from "../helpers/createInstance";
+import { createReconciler } from "../helpers/createReconciler";
+import { createTextInstance } from "../helpers/createTextInstance";
+import { detachDeletedInstance } from "../helpers/detachDeletedInstance";
+import { finalizeInitialChildren } from "../helpers/finalizeInitialChildren";
+import { getChildHostContext } from "../helpers/getChildHostContext";
+import { getCurrentUpdatePriority } from "../helpers/getCurrentUpdatePriority";
+import { getInstanceFromNode } from "../helpers/getInstanceFromNode";
+import { getInstanceFromScope } from "../helpers/getInstanceFromScope";
+import { getPublicInstance } from "../helpers/getPublicInstance";
+import { getRootHostContext } from "../helpers/getRootHostContext";
+import { hideInstance } from "../helpers/hideInstance";
+import { hideTextInstance } from "../helpers/hideTextInstance";
+import { insertBefore } from "../helpers/insertBefore";
+import { maySuspendCommit } from "../helpers/maySuspendCommit";
+import { preloadInstance } from "../helpers/preloadInstance";
+import { prepareForCommit } from "../helpers/prepareForCommit";
+import { preparePortalMount } from "../helpers/preparePortalMount";
+import { prepareScopeUpdate } from "../helpers/prepareScopeUpdate";
+import { removeChild } from "../helpers/removeChild";
+import { requestPostPaintCallback } from "../helpers/requestPostPaintCallback";
+import { resetAfterCommit } from "../helpers/resetAfterCommit";
+import { resetFormInstance } from "../helpers/resetFormInstance";
+import { resolveEventTimeStamp } from "../helpers/resolveEventTimeStamp";
+import { resolveEventType } from "../helpers/resolveEventType";
+import { resolveUpdatePriority } from "../helpers/resolveUpdatePriority";
+import { setCurrentUpdatePriority } from "../helpers/setCurrentUpdatePriority";
+import { shouldAttemptEagerTransition } from "../helpers/shouldAttemptEagerTransition";
+import { shouldSetTextContent } from "../helpers/shouldSetTextContent";
+import { startSuspendingCommit } from "../helpers/startSuspendingCommit";
+import { suspendInstance } from "../helpers/suspendInstance";
+import { trackSchedulerEvent } from "../helpers/trackSchedulerEvent";
+import { unhideInstance } from "../helpers/unhideInstance";
+import { unhideTextInstance } from "../helpers/unhideTextInstance";
+import { waitForCommitToBeReady } from "../helpers/waitForCommitToBeReady";
+import { type HostConfig } from "../typedefs/HostConfig";
 
-const reconcilerConfig = {
+const reconciler = /* @__PURE__ */ createReconciler<
+    HostConfig["type"],
+    HostConfig["props"],
+    HostConfig["containerInstance"],
+    HostConfig["instance"],
+    HostConfig["textInstance"],
+    HostConfig["suspenseInstance"],
+    HostConfig["hydratableInstance"],
+    HostConfig["formInstance"],
+    HostConfig["publicInstance"],
+    HostConfig["hostContext"],
+    HostConfig["childSet"],
+    HostConfig["timeoutHandle"],
+    HostConfig["noTimeout"],
+    HostConfig["transitionStatus"]
+>({
     isPrimaryRenderer: false,
     noTimeout: -1,
     NotPendingTransition: null,
@@ -95,29 +109,73 @@ const reconcilerConfig = {
     trackSchedulerEvent,
     unhideInstance,
     waitForCommitToBeReady,
-};
 
-const reconciler = createReconciler<
-    HostConfig['type'],
-    HostConfig['props'],
-    HostConfig['containerInstance'],
-    HostConfig['instance'],
-    HostConfig['textInstance'],
-    HostConfig['suspenseInstance'],
-    HostConfig['hydratableInstance'],
-    HostConfig['formInstance'],
-    HostConfig['publicInstance'],
-    HostConfig['hostContext'],
-    HostConfig['childSet'],
-    HostConfig['timeoutHandle'],
-    HostConfig['noTimeout'],
-    HostConfig['transitionStatus']
->(reconcilerConfig);
-
-reconciler.injectIntoDevTools({
-    bundleType: process.env.NODE_ENV === 'production' ? 0 : 1,
-    rendererPackageName: '@pixi/react',
-    version: packageData.version,
+    // @ts-expect-error untyped 19.x features
+    // https://github.com/facebook/react/pull/31975
+    // https://github.com/facebook/react/pull/31999
+    applyViewTransitionName(_instance: any, _name: any, _className: any) {},
+    restoreViewTransitionName(_instance: any, _props: any) {},
+    cancelViewTransitionName(_instance: any, _name: any, _props: any) {},
+    cancelRootViewTransitionName(_rootContainer: any) {},
+    restoreRootViewTransitionName(_rootContainer: any) {},
+    InstanceMeasurement: null,
+    measureInstance: (_instance: any) => null,
+    wasInstanceInViewport: (_measurement: any): boolean => true,
+    hasInstanceChanged: (_oldMeasurement: any, _newMeasurement: any): boolean =>
+        false,
+    hasInstanceAffectedParent: (
+        _oldMeasurement: any,
+        _newMeasurement: any
+    ): boolean => false,
+    // https://github.com/facebook/react/pull/32002
+    // https://github.com/facebook/react/pull/34486
+    suspendOnActiveViewTransition(_state: any, _container: any) {},
+    // https://github.com/facebook/react/pull/32451
+    // https://github.com/facebook/react/pull/32760
+    startGestureTransition: () => null,
+    startViewTransition: () => null,
+    stopViewTransition(_transition: null) {},
+    // https://github.com/facebook/react/pull/32038
+    createViewTransitionInstance: (_name: string): null => null,
+    // https://github.com/facebook/react/pull/32379
+    // https://github.com/facebook/react/pull/32786
+    getCurrentGestureOffset(_provider: null): number {
+        throw new Error(
+            "startGestureTransition is not yet supported in React Pixi."
+        );
+    },
+    // https://github.com/facebook/react/pull/32500
+    cloneMutableInstance(instance: any, _keepChildren: any) {
+        return instance;
+    },
+    cloneMutableTextInstance(textInstance: any) {
+        return textInstance;
+    },
+    cloneRootViewTransitionContainer(_rootContainer: any) {
+        throw new Error("Not implemented.");
+    },
+    removeRootViewTransitionClone(_rootContainer: any, _clone: any) {
+        throw new Error("Not implemented.");
+    },
+    // https://github.com/facebook/react/pull/32465
+    createFragmentInstance: (_fiber: any): null => null,
+    updateFragmentInstanceFiber(_fiber: any, _instance: any): void {},
+    commitNewChildToFragmentInstance(
+        _child: any,
+        _fragmentInstance: any
+    ): void {},
+    deleteChildFromFragmentInstance(
+        _child: any,
+        _fragmentInstance: any
+    ): void {},
+    // https://github.com/facebook/react/pull/32653
+    measureClonedInstance: (_instance: any) => null,
+    // https://github.com/facebook/react/pull/32819
+    maySuspendCommitOnUpdate: (_type: any, _oldProps: any, _newProps: any) =>
+        false,
+    maySuspendCommitInSyncRender: (_type: any, _props: any) => false,
+    // https://github.com/facebook/react/pull/34522
+    getSuspendedCommitReason: (_state: any, _rootContainer: any) => null,
 });
 
 export { reconciler };

--- a/src/helpers/createReconciler.ts
+++ b/src/helpers/createReconciler.ts
@@ -1,7 +1,7 @@
-import Reconciler from 'react-reconciler';
-import { type EventPriority } from '../typedefs/EventPriority';
+import Reconciler from "react-reconciler";
+import packageData from '../../package.json' with { type: 'json' };
 
-export const createReconciler = Reconciler as unknown as <
+export function createReconciler<
     Type,
     Props,
     Container,
@@ -15,95 +15,41 @@ export const createReconciler = Reconciler as unknown as <
     ChildSet,
     TimeoutHandle,
     NoTimeout,
-    TransitionStatus,
+    TransitionStatus
 >(
-    config: Omit<
-        Reconciler.HostConfig<
-            Type,
-            Props,
-            Container,
-            Instance,
-            TextInstance,
-            SuspenseInstance,
-            HydratableInstance,
-            PublicInstance,
-            HostContext,
-            null, // updatePayload
-            ChildSet,
-            TimeoutHandle,
-            NoTimeout
-        >,
-    'getCurrentEventPriority' | 'prepareUpdate' | 'commitUpdate'
-    > & {
-        /**
-         * This method should mutate the `instance` and perform prop diffing if needed.
-         *
-         * The `internalHandle` data structure is meant to be opaque. If you bend the rules and rely on its internal fields, be aware that it may change significantly between versions. You're taking on additional maintenance risk by reading from it, and giving up all guarantees if you write something to it.
-         */
-        commitUpdate?(
-            instance: Instance,
-            type: Type,
-            prevProps: Props,
-            nextProps: Props,
-            internalHandle: Reconciler.OpaqueHandle,
-        ): void
+    config: Reconciler.HostConfig<
+        Type,
+        Props,
+        Container,
+        Instance,
+        TextInstance,
+        SuspenseInstance,
+        HydratableInstance,
+        FormInstance,
+        PublicInstance,
+        HostContext,
+        ChildSet,
+        TimeoutHandle,
+        NoTimeout,
+        TransitionStatus
+    >
+): Reconciler.Reconciler<
+        Container,
+        Instance,
+        TextInstance,
+        SuspenseInstance,
+        FormInstance,
+        PublicInstance
+    > {
+    const reconciler = Reconciler({
+        ...config,
+        // @ts-expect-error https://github.com/facebook/react/pull/30522
+        rendererPackageName: "@pixi/react",
+        version: packageData.version,
+    });
 
-        // Undocumented
-        // https://github.com/facebook/react/pull/26722
-        NotPendingTransition: TransitionStatus | null
+    // @ts-expect-error https://github.com/facebook/react/pull/30522
+    reconciler.injectIntoDevTools();
 
-        // https://github.com/facebook/react/pull/28751
-        setCurrentUpdatePriority(newPriority: EventPriority): void
-
-        getCurrentUpdatePriority(): EventPriority
-
-        resolveUpdatePriority(): EventPriority
-
-        // https://github.com/facebook/react/pull/28804
-        resetFormInstance(form: FormInstance): void
-
-        // https://github.com/facebook/react/pull/25105
-        requestPostPaintCallback(callback: (time: number) => void): void
-
-        // https://github.com/facebook/react/pull/26025
-        shouldAttemptEagerTransition(): boolean
-
-        // https://github.com/facebook/react/pull/31528
-        trackSchedulerEvent(): void
-
-        // https://github.com/facebook/react/pull/31008
-        resolveEventType(): null | string
-
-        resolveEventTimeStamp(): number
-
-        /**
-         * This method is called during render to determine if the Host Component type and props require some kind of loading process to complete before committing an update.
-         */
-        maySuspendCommit(type: Type, props: Props): boolean
-
-        /**
-         * This method may be called during render if the Host Component type and props might suspend a commit. It can be used to initiate any work that might shorten the duration of a suspended commit.
-         */
-        preloadInstance(type: Type, props: Props): boolean
-
-        /**
-         * This method is called just before the commit phase. Use it to set up any necessary state while any Host Components that might suspend this commit are evaluated to determine if the commit must be suspended.
-         */
-        startSuspendingCommit(): void
-
-        /**
-         * This method is called after `startSuspendingCommit` for each Host Component that indicated it might suspend a commit.
-         */
-        suspendInstance(type: Type, props: Props): void
-
-        /**
-         * This method is called after all `suspendInstance` calls are complete.
-         *
-         * Return `null` if the commit can happen immediately.
-         *
-         * Return `(initiateCommit: Function) => Function` if the commit must be suspended. The argument to this callback will initiate the commit when called. The return value is a cancellation function that the Reconciler can use to abort the commit.
-         *
-         */
-        waitForCommitToBeReady(): ((initiateCommit: (...args: unknown[]) => unknown) => (...args: unknown[]) => unknown) | null
-    },
-) => Reconciler.Reconciler<Container, Instance, TextInstance, SuspenseInstance, PublicInstance>;
+    return reconciler as any;
+}

--- a/src/helpers/startSuspendingCommit.ts
+++ b/src/helpers/startSuspendingCommit.ts
@@ -3,4 +3,7 @@ import { log } from './log';
 export function startSuspendingCommit()
 {
     log('info', 'lifecycle::startSuspendingCommit');
+
+    // https://github.com/facebook/react/pull/34486
+    return null;
 }

--- a/test/e2e/components/Application.test.tsx
+++ b/test/e2e/components/Application.test.tsx
@@ -4,6 +4,7 @@ import {
     createRef,
     useContext,
     useEffect,
+    useEffectEvent,
 } from 'react';
 import {
     describe,
@@ -214,5 +215,27 @@ describe('Application', () =>
 
         expect(addSpy).toHaveBeenCalledWith(customLoader);
         addSpy.mockRestore();
+    });
+
+    it("can handle future (19.x) hooks without crashing", async () => {
+        let hookWasCalled = false
+
+        function Test() {
+            useEffectEvent(() => {});
+            hookWasCalled = true;
+            return null;
+        }
+
+        expect(
+            async () =>
+                await act(async () =>
+                    render(
+                        <Application>
+                            <Test />
+                        </Application>
+                    )
+                )
+        ).not.toThrow();
+        expect(hookWasCalled).toBe(true)
     });
 });


### PR DESCRIPTION
Mirrors https://github.com/pmndrs/react-three-fiber/pull/3606.

> Updates the reconciler to support React 19.2, including `<Activity />` and `useEffectEvent()`.
> 
> Because `react-reconciler` is published in lockstep with the React package, it is not seen as forwards compatible since React 19 and supports 19.2+.
> 
> We bundle `react-reconciler` for the moment since we are sure these features are forward compatible and do not present a breaking change. React packages inline the reconciler as well, but we have to ship both the development and production bundles.