### PR TITLE
Fix release resources lifecycle on root destroy

### DIFF
--- a/src/helpers/unmountRoot.ts
+++ b/src/helpers/unmountRoot.ts
@@ -15,7 +15,7 @@ export function unmountRoot(root: Root)
         {
             if (root.applicationState.app)
             {
-                root.applicationState.app.destroy();
+                root.applicationState.app.destroy(true, true);
             }
 
             roots.delete(root.internalState.canvas!);


### PR DESCRIPTION
I've been struggling with being stuck at Pixi js <8.12 due to an application lifecycle issue. **This only happens on >8.13**. I think they stem from these changes in batching -- https://github.com/pixijs/pixijs/pull/10885 & https://github.com/pixijs/pixijs/pull/11581

The app renders correctly on first render, but when I navigate to a non Pixi view on the react app, and back to the pixi application, I'm greeted with a pixi crash:

```
Uncaught TypeError: Cannot read properties of undefined (reading 'destroy')
    at GpuBufferSystem.onBufferChange (GpuBufferSystem.ts:107:19)
    at Buffer.emit (index.js:181:35)
    at Buffer.setDataWithSize (Buffer.ts:276:22)
    at _GraphicsContextSystem2._initContextRenderData (GraphicsContextSystem.ts:252:30)
    at _GraphicsContextSystem2.getContextRenderData (GraphicsContextSystem.ts:152:67)
    at GpuGraphicsAdaptor.execute (GpuGraphicsAdaptor.ts:78:27)
    at GraphicsPipe.execute (GraphicsPipe.ts:153:23)
    at executeInstructions (executeInstructions.ts:19:91)
    at RenderGroupPipe._executeDirect (RenderGroupPipe.ts:136:29)
    at RenderGroupPipe.execute (RenderGroupPipe.ts:58:18)
```

I've added some comments in this issue https://github.com/pixijs/pixijs/issues/11694, thinking this was an unsafe handling of the GPU Batches: I still feel that this kind of crash is not very graceful. But perhaps this is something we need to fix here also.

https://github.com/pixijs/pixi-react/pull/625 reported that this happens only or React Strict, but it can also happen on navigation back and forth to the pixi application.

I've played around with the `releaseGlobalResources` and `removeView`, but only setting them both to true seems to work. It would be nice to prevet full destruction of the application between navigation events tho.
