### PR TITLE
Expose Application destroy options

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,9 +127,17 @@ const MyComponent = () => {
 > [!NOTE]
 > This property **is not retroactive**. It will only apply to text components created after `defaultTextStyle` is set. Any text components created before setting `defaultTextStyle` will retain the base styles they had before `defaultTextStyle` was changed.
 
+###### `destroyOptions`
+
+When an `<Application>` is unmounted, it will call the `destroy()` method on the Pixi.js application instance. Provide this prop to override the default `DestroyOptions` (the second argument to `destroy()`). See Pixi.js's [`destroy documentation`](https://pixijs.download/release/docs/app.Application.html#destroy) for more info.
+
 ###### `extensions`
 
 `extensions` is an array of extensions to be loaded. Adding and removing items from this array will automatically load/unload the extensions. The first time this is handled happens before the application is initialised. See Pixi.js's [`extensions`](https://pixijs.download/release/docs/extensions.html) documentation for more info on extensions.
+
+###### `rendererDestroyOptions`
+
+When an `<Application>` is unmounted, it will call the `destroy()` method on the Pixi.js application instance. Provide this prop to override the default `RendererDestroyOptions` (the first argument to `destroy()`). See Pixi.js's [`destroy documentation`](https://pixijs.download/release/docs/app.Application.html#destroy) for more info.
 
 ###### `resizeTo`
 

--- a/src/components/Application.tsx
+++ b/src/components/Application.tsx
@@ -36,8 +36,10 @@ const ApplicationImplementation = forwardRef<ApplicationRef, ApplicationProps>(f
         children,
         className,
         defaultTextStyle,
+        destroyOptions,
         extensions,
         onInit,
+        rendererDestroyOptions,
         resizeTo,
         ...applicationProps
     } = props;
@@ -138,7 +140,11 @@ const ApplicationImplementation = forwardRef<ApplicationRef, ApplicationProps>(f
 
             if (!root)
             {
-                root = createRoot(canvasElement, { onInit: handleInit });
+                root = createRoot(canvasElement, {
+                    destroyOptions,
+                    onInit: handleInit,
+                    rendererDestroyOptions,
+                });
             }
 
             // @ts-expect-error The value of `children` is fine, but `PixiReactChildNode` doesn't strictly adhere to the `ReactNode` structure.
@@ -147,7 +153,9 @@ const ApplicationImplementation = forwardRef<ApplicationRef, ApplicationProps>(f
     }, [
         applicationProps,
         children,
+        destroyOptions,
         handleInit,
+        rendererDestroyOptions,
         resizeTo,
     ]);
 

--- a/src/core/createRoot.tsx
+++ b/src/core/createRoot.tsx
@@ -25,8 +25,10 @@ export function createRoot(
     // Check against mistaken use of createRoot
     let root = roots.get(target);
     let applicationState = (root?.applicationState ?? {
+        destroyOptions: options.destroyOptions,
         isInitialised: false,
         isInitialising: false,
+        rendererDestroyOptions: options.rendererDestroyOptions,
     }) as ApplicationState;
 
     const internalState = root?.internalState ?? {} as InternalState;

--- a/src/helpers/unmountRoot.ts
+++ b/src/helpers/unmountRoot.ts
@@ -15,7 +15,10 @@ export function unmountRoot(root: Root)
         {
             if (root.applicationState.app)
             {
-                root.applicationState.app.destroy();
+                root.applicationState.app.destroy(
+                    root.applicationState.rendererDestroyOptions,
+                    root.applicationState.destroyOptions
+                );
             }
 
             roots.delete(root.internalState.canvas!);

--- a/src/typedefs/ApplicationProps.ts
+++ b/src/typedefs/ApplicationProps.ts
@@ -1,7 +1,9 @@
 import {
     type Application,
     type ApplicationOptions,
+    type DestroyOptions,
     type ExtensionFormatLoose,
+    type RendererDestroyOptions,
     type TextStyle,
     type TextStyleOptions,
 } from 'pixi.js';
@@ -22,6 +24,9 @@ export interface BaseApplicationProps
     /** @description The default style to be applied to text nodes. */
     defaultTextStyle?: TextStyle | TextStyleOptions,
 
+    /** @description Options to be passed to the application's `destroy` method. */
+    destroyOptions?: DestroyOptions
+
     /** @description An array of Pixi extensions to be loaded before initialisation. */
     extensions?: (ExtensionFormatLoose | any)[],
 
@@ -30,6 +35,9 @@ export interface BaseApplicationProps
 
     /** @description Callback to be fired when the application finishes initializing. */
     onInit?: (app: Application) => void
+
+    /** @description Options to be passed to the application's `renderer.destroy` method. */
+    rendererDestroyOptions?: RendererDestroyOptions
 
     /** @description An element (or React ref) to which the application's canvas will be resized. */
     resizeTo?: HTMLElement | Window | RefObject<HTMLElement | null>

--- a/src/typedefs/ApplicationState.ts
+++ b/src/typedefs/ApplicationState.ts
@@ -1,8 +1,10 @@
-import { type Application } from 'pixi.js';
+import { type Application, type DestroyOptions, type RendererDestroyOptions } from 'pixi.js';
 
 export interface ApplicationState
 {
     app: Application;
+    destroyOptions: DestroyOptions;
     isInitialised: boolean;
     isInitialising: boolean;
+    rendererDestroyOptions: RendererDestroyOptions;
 }

--- a/src/typedefs/CreateRootOptions.ts
+++ b/src/typedefs/CreateRootOptions.ts
@@ -1,7 +1,13 @@
-import { type Application } from 'pixi.js';
+import { type Application, type DestroyOptions, type RendererDestroyOptions } from 'pixi.js';
 
 export interface CreateRootOptions
 {
+    /** @description Options to be passed to the application's `destroy` method. */
+    destroyOptions?: DestroyOptions
+
     /** @description Callback to be fired when the application finishes initializing. */
     onInit?: (app: Application) => void
+
+    /** @description Options to be passed to the application's `renderer.destroy` method. */
+    rendererDestroyOptions?: RendererDestroyOptions
 }

--- a/test/e2e/components/Application.test.tsx
+++ b/test/e2e/components/Application.test.tsx
@@ -1,4 +1,4 @@
-import { Application as PixiApplication, extensions as PixiExtensions, ExtensionType } from 'pixi.js';
+import { Application as PixiApplication, type DestroyOptions, extensions as PixiExtensions, ExtensionType, type RendererDestroyOptions } from 'pixi.js';
 import {
     createContext,
     createRef,
@@ -98,6 +98,9 @@ describe('Application', () =>
             let testApp = null as any as PixiApplication;
             let testAppIsInitialised = false;
 
+            const destroyOptions: DestroyOptions = { children: true };
+            const rendererDestroyOptions: RendererDestroyOptions = { removeView: true };
+
             const TestChildComponent = () =>
             {
                 const {
@@ -124,7 +127,10 @@ describe('Application', () =>
             };
 
             const TestComponent = () => (
-                <Application>
+                <Application
+                    destroyOptions={destroyOptions}
+                    rendererDestroyOptions={rendererDestroyOptions}
+                >
                     <TestChildComponent />
                 </Application>
             );
@@ -137,11 +143,16 @@ describe('Application', () =>
 
             await expect.poll(() => testAppIsInitialised).toEqual(true);
 
+            const destroySpy = vi.spyOn(testApp, 'destroy');
+
             unmount();
 
             expect(roots.size).toEqual(0);
 
             await expect.poll(() => isAppMounted(testApp)).toBeFalsy();
+
+            expect(destroySpy).toHaveBeenCalledTimes(1);
+            expect(destroySpy).toHaveBeenCalledWith(rendererDestroyOptions, destroyOptions);
         });
 
         it('unmounts during init', async () =>

--- a/test/e2e/components/Application.test.tsx
+++ b/test/e2e/components/Application.test.tsx
@@ -98,7 +98,115 @@ describe('Application', () =>
             let testApp = null as any as PixiApplication;
             let testAppIsInitialised = false;
 
+            const TestChildComponent = () =>
+            {
+                const {
+                    app,
+                    isInitialised,
+                } = useApplication();
+
+                useEffect(() =>
+                {
+                    testApp = app;
+                    testAppIsInitialised = isInitialised;
+
+                    return () =>
+                    {
+                        testApp = app;
+                        testAppIsInitialised = isInitialised;
+                    };
+                }, [
+                    app,
+                    isInitialised,
+                ]);
+
+                return null;
+            };
+
+            const TestComponent = () => (
+                <Application>
+                    <TestChildComponent />
+                </Application>
+            );
+
+            expect(roots.size).toEqual(0);
+
+            const { unmount } = await act(() => render(<TestComponent />));
+
+            expect(roots.size).toEqual(1);
+
+            await expect.poll(() => testAppIsInitialised).toEqual(true);
+
+            unmount();
+
+            expect(roots.size).toEqual(0);
+
+            await expect.poll(() => isAppMounted(testApp)).toBeFalsy();
+        });
+
+        it('unmounts with destroyOptions', async () =>
+        {
+            let testApp = null as any as PixiApplication;
+            let testAppIsInitialised = false;
+
             const destroyOptions: DestroyOptions = { children: true };
+
+            const TestChildComponent = () =>
+            {
+                const {
+                    app,
+                    isInitialised,
+                } = useApplication();
+
+                useEffect(() =>
+                {
+                    testApp = app;
+                    testAppIsInitialised = isInitialised;
+
+                    return () =>
+                    {
+                        testApp = app;
+                        testAppIsInitialised = isInitialised;
+                    };
+                }, [
+                    app,
+                    isInitialised,
+                ]);
+
+                return null;
+            };
+
+            const TestComponent = () => (
+                <Application destroyOptions={destroyOptions}>
+                    <TestChildComponent />
+                </Application>
+            );
+
+            expect(roots.size).toEqual(0);
+
+            const { unmount } = await act(() => render(<TestComponent />));
+
+            expect(roots.size).toEqual(1);
+
+            await expect.poll(() => testAppIsInitialised).toEqual(true);
+
+            const destroySpy = vi.spyOn(testApp, 'destroy');
+
+            unmount();
+
+            expect(roots.size).toEqual(0);
+
+            await expect.poll(() => isAppMounted(testApp)).toBeFalsy();
+
+            expect(destroySpy).toHaveBeenCalledTimes(1);
+            expect(destroySpy).toHaveBeenCalledWith(undefined, destroyOptions);
+        });
+
+        it('unmounts with rendererDestroyOptions', async () =>
+        {
+            let testApp = null as any as PixiApplication;
+            let testAppIsInitialised = false;
+
             const rendererDestroyOptions: RendererDestroyOptions = { removeView: true };
 
             const TestChildComponent = () =>
@@ -127,10 +235,7 @@ describe('Application', () =>
             };
 
             const TestComponent = () => (
-                <Application
-                    destroyOptions={destroyOptions}
-                    rendererDestroyOptions={rendererDestroyOptions}
-                >
+                <Application rendererDestroyOptions={rendererDestroyOptions}>
                     <TestChildComponent />
                 </Application>
             );
@@ -152,7 +257,7 @@ describe('Application', () =>
             await expect.poll(() => isAppMounted(testApp)).toBeFalsy();
 
             expect(destroySpy).toHaveBeenCalledTimes(1);
-            expect(destroySpy).toHaveBeenCalledWith(rendererDestroyOptions, destroyOptions);
+            expect(destroySpy).toHaveBeenCalledWith(rendererDestroyOptions, undefined);
         });
 
         it('unmounts during init', async () =>

--- a/test/unit/core/createRoot.test.ts
+++ b/test/unit/core/createRoot.test.ts
@@ -8,7 +8,7 @@ import { createRoot } from '../../../src/core/createRoot';
 
 describe('createRoot', () =>
 {
-    it('creates a new root with default options', () =>
+    it('creates a new root', () =>
     {
         const target = document.createElement('canvas');
         const root = createRoot(target);

--- a/test/unit/core/createRoot.test.ts
+++ b/test/unit/core/createRoot.test.ts
@@ -8,19 +8,57 @@ import { createRoot } from '../../../src/core/createRoot';
 
 describe('createRoot', () =>
 {
-    it('creates a new root', () =>
+    it('creates a new root with default options', () =>
     {
         const target = document.createElement('canvas');
         const root = createRoot(target);
 
         expect(root).toHaveProperty('fiber');
         expect(root).toHaveProperty('render');
-        expect(root).toHaveProperty('render');
         expect(root).toHaveProperty('applicationState');
         expect(root).toHaveProperty('internalState');
         expect(root.render).toBeTypeOf('function');
         expect(root.internalState).toHaveProperty('rootContainer');
         expect(root.applicationState.app).toBeInstanceOf(Application);
+        expect(root.applicationState.destroyOptions).toBeUndefined();
+        expect(root.applicationState.rendererDestroyOptions).toBeUndefined();
         expect(root.internalState.rootContainer).toEqual(root.applicationState.app.stage);
+    });
+
+    describe('with destroy options', () =>
+    {
+        it('creates a new root with boolean destroy options', () =>
+        {
+            const target = document.createElement('canvas');
+            const root = createRoot(target, {
+                destroyOptions: true,
+                rendererDestroyOptions: false,
+            });
+
+            expect(root.applicationState.destroyOptions).toBe(true);
+            expect(root.applicationState.rendererDestroyOptions).toBe(false);
+        });
+
+        it('creates a new root with object destroy options', () =>
+        {
+            const target = document.createElement('canvas');
+            const root = createRoot(target, {
+                destroyOptions: { children: true },
+            });
+
+            expect(root.applicationState.destroyOptions).toEqual({ children: true });
+            expect(root.applicationState.rendererDestroyOptions).toBeUndefined();
+        });
+
+        it('creates a new root with object renderer destroy options', () =>
+        {
+            const target = document.createElement('canvas');
+            const root = createRoot(target, {
+                rendererDestroyOptions: { removeView: true },
+            });
+
+            expect(root.applicationState.destroyOptions).toBeUndefined();
+            expect(root.applicationState.rendererDestroyOptions).toEqual({ removeView: true });
+        });
     });
 });


### PR DESCRIPTION
I discovered various issues that arise from rendering multiple Pixi.js applications on a page at once. When one application is unmounted, it can cause issues for other existing application instances on the page -- graphics may randomly disappear and reappear or render incorrectly.

My assumption is that the default destroy behavior is affecting shared resources in a way that's unintended and causes instability.

This PR adds new `destroyOptions` and `rendererDestroyOptions` props on `<Application>` that are stored until the component is unmounted. At that point, these options will be passed to the application's `destroy()` method. Ultimately, it allows consumers of `pixi/react` to better control the lifecycle and destroy behavior of their applications and hopefully avoid these kinds of issues.

See also: https://github.com/pixijs/pixi-react/pull/639