### PR TITLE
chore: Add permissions for trusted publishing

### DIFF
--- a/.github/workflows/handle-release-branch-push.yml
+++ b/.github/workflows/handle-release-branch-push.yml
@@ -5,6 +5,10 @@ on:
   pull_request:
   push:
 
+permissions:
+  id-token: write # Required for OIDC
+  contents: write # Required for npm beta version updates
+
 jobs:
   verify:
     name: Verify


### PR DESCRIPTION
Adds required permissions for the GitHub Actions workflow to handle trusted publishing of new releases to the npm registry.
