### PR TITLE
fix: provide extensions for react-reconciler imports

### DIFF
--- a/src/helpers/resolveUpdatePriority.ts
+++ b/src/helpers/resolveUpdatePriority.ts
@@ -2,7 +2,7 @@ import {
     ContinuousEventPriority,
     DefaultEventPriority,
     DiscreteEventPriority,
-} from 'react-reconciler/constants';
+} from 'react-reconciler/constants.js';
 import { store } from '../store';
 import { log } from './log';
 

--- a/src/store.ts
+++ b/src/store.ts
@@ -1,4 +1,4 @@
-import { DefaultEventPriority } from 'react-reconciler/constants';
+import { DefaultEventPriority } from 'react-reconciler/constants.js';
 import { type Root } from './typedefs/Root';
 
 const store: {


### PR DESCRIPTION
An ESM import of 'some/file' must include the extension unless the imported module has an 'exports' field.
react-reconciler doesn't provide one, so the .js extension is necessary.

This should close https://github.com/pixijs/pixi-react/issues/614