### PR TITLE
fix(core): use latest children & options after async app.init()

### DIFF
--- a/src/core/createRoot.tsx
+++ b/src/core/createRoot.tsx
@@ -74,11 +74,23 @@ export function createRoot(
 
         internalState.canvas = canvas;
 
+        // Track the most recent arguments passed to `render`. Because `render` is async
+        // (it awaits `app.init()` on the first call), a later `render` call can arrive
+        // and update the fiber/app with newer state while the first call is still
+        // awaiting. Without this, the first call would resume after init and overwrite
+        // both the committed children and the applied application options with its now
+        // stale closure values.
+        let latestRenderChildren: ReactNode = null;
+        let latestRenderOptions: ApplicationOptions | null = null;
+
         const render = async (
             children: ReactNode,
             applicationOptions: ApplicationOptions,
         ) =>
         {
+            latestRenderChildren = children;
+            latestRenderOptions = applicationOptions;
+
             if (!applicationState.app.renderer && !applicationState.isInitialised && !applicationState.isInitialising)
             {
                 applicationState.isInitialising = true;
@@ -90,6 +102,14 @@ export function createRoot(
                 applicationState.isInitialised = true;
                 applicationState = { ...applicationState };
                 options.onInit?.(applicationState.app);
+
+                // After the async init, use the latest arguments rather than the stale
+                // closure values — a concurrent `render` call may already have pushed
+                // newer children into the fiber and applied newer options to the app,
+                // and we must not revert those updates. Committing the same children a
+                // second time is a no-op: React bails out on referential equality.
+                children = latestRenderChildren;
+                applicationOptions = latestRenderOptions;
             }
 
             Object.entries(applicationOptions).forEach(([key, value]) =>

--- a/test/unit/core/createRoot.test.ts
+++ b/test/unit/core/createRoot.test.ts
@@ -3,8 +3,10 @@ import {
     describe,
     expect,
     it,
+    vi,
 } from 'vitest';
 import { createRoot } from '../../../src/core/createRoot';
+import { reconciler } from '../../../src/core/reconciler';
 
 describe('createRoot', () =>
 {
@@ -59,6 +61,60 @@ describe('createRoot', () =>
 
             expect(root.applicationState.destroyOptions).toBeUndefined();
             expect(root.applicationState.rendererDestroyOptions).toEqual({ removeView: true });
+        });
+    });
+
+    describe('async init race condition', () =>
+    {
+        it('commits the latest children and options when a second render arrives during init', async () =>
+        {
+            const target = document.createElement('canvas');
+
+            // Control exactly when `app.init()` resolves so we can interleave a second
+            // render() call while the first is still awaiting initialisation.
+            let resolveInit!: () => void;
+            const initGate = new Promise<void>((resolve) =>
+            {
+                resolveInit = resolve;
+            });
+            const initSpy = vi
+                .spyOn(Application.prototype, 'init')
+                .mockImplementation(async function mockInit(this: Application)
+                {
+                    await initGate;
+                    // Emulate the renderer becoming available once init resolves.
+                    (this as unknown as { renderer: object }).renderer = {};
+                });
+
+            // Capture what gets committed to the fiber without running the real reconciler.
+            const updateSpy = vi
+                .spyOn(reconciler, 'updateContainer')
+                .mockReturnValue(true as never);
+
+            const root = createRoot(target);
+
+            // First render kicks off init and suspends on the await.
+            const firstRender = root.render('A' as never, { __opt: 'A' } as never);
+            // Second render arrives during the init window: it sees isInitialising===true,
+            // skips init, and synchronously commits its newer children/options.
+            const secondRender = root.render('B' as never, { __opt: 'B' } as never);
+
+            // Now let the first init resolve and the first render resume.
+            resolveInit();
+            await Promise.all([firstRender, secondRender]);
+
+            // The final committed tree must carry the latest children ('B'), not the
+            // stale 'A' captured in the first render's closure.
+            const lastCommit = updateSpy.mock.calls.at(-1)?.[0] as { props: { children: unknown } };
+
+            expect(lastCommit.props.children).toBe('B');
+
+            // The latest application options must also win — the resumed first render
+            // must not revert app properties to its stale options.
+            expect((root.applicationState.app as unknown as { __opt: string }).__opt).toBe('B');
+
+            initSpy.mockRestore();
+            updateSpy.mockRestore();
         });
     });
 });


### PR DESCRIPTION
## Problem

`createRoot`'s `render()` is `async` and `await`s `app.init()` on the first call. If a **second** `render()` arrives while the first is still awaiting init (e.g. the parent re-renders due to a resize/layout change), the second call sees `isInitialising === true`, skips the init branch, applies its newer `applicationOptions` and commits its **newer** children — correct so far.

But when the first call's `await app.init()` finally resolves, it continues using the **stale `children` and `applicationOptions`** captured in its own closure: it re-applies the old options to the app (potentially reverting canvas `width`/`height`, etc.) and calls `reconciler.updateContainer(...)` with the old tree. This reverts both the app state and the fiber to the older values.

```
render(childrenA, optsA)  →  isInitialising = true  →  await app.init() … (suspended)
                                                          │
   parent re-renders (resize) during init                │
   render(childrenB, optsB) → isInitialising === true     │
                            → applies optsB, commits B  ✓ │
                                                          │
   app.init() resolves ◄──────────────────────────────────┘
   render(childrenA, optsA) resumes
                            → re-applies optsA, commits A  ✗ STALE — reverts B
```

We hit this on hard page refresh (not on SPA navigation): surrounding UI finishes loading and shrinks the container within the `app.init()` window, so a `ResizeObserver`-driven second render lands mid-init. The result is children rendered with the pre-resize tree/size — in our app, coordinate-bound objects snap to the screen origin instead of their correct positions.

## Root cause

The first `render` invocation closes over **both** its `children` and `applicationOptions` arguments and re-uses them after the `await`, unaware that a later invocation already pushed newer values into the fiber/app.

## Fix

Track the most recent `children` and `applicationOptions` in closure variables shared across `render` calls, and after `await app.init()` completes, use those latest values instead of the stale closure arguments.

## Why this is safe

- Only the post-init branch changes; the `applicationOptions` apply loop and the final `updateContainer` are untouched.
- With no concurrent second render, the latest values equal the closure arguments, so behaviour is identical to before.
- In the race case, `updateContainer` is called a second time with the children the concurrent render already committed — React bails out on referential equality, so there's no extra render cost.
- This is purely "prefer the newest arguments", matching React's own last-write-wins reconciliation semantics.

## Test

Adds a unit test in `test/unit/core/createRoot.test.ts` that reproduces the race by gating `Application.prototype.init` behind a controllable promise, issuing a second `render()` during the init window, then resolving init. It asserts the final committed children and applied options both reflect the **second** render. The test fails without the fix (the resumed first render overwrites with stale `'A'`) and passes with it.

Verified locally: `vitest run unit` → all unit tests pass; `xs lint` → no new errors.
